### PR TITLE
ci: add GitHub Actions build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary
- Runs `go build ./...` and `go test ./...` on every PR and push to main
- Uses Go version from `go.mod`

Once merged, add **"Build & Test"** as a required status check in the branch protection rule for `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)