### PR TITLE
ci: use PAT for release-please to bypass branch protection

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Switches release-please from `GITHUB_TOKEN` to a fine-grained PAT (`RELEASE_PLEASE_TOKEN`)
- PRs created by the PAT are owned by you (repo admin), so they can be merged without requiring a review bypass rule

## Setup
Add the token as a repo secret named `RELEASE_PLEASE_TOKEN` (Settings → Secrets and variables → Actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)