### PR TITLE
chore: remove dead code

### DIFF
--- a/internal/api/players.go
+++ b/internal/api/players.go
@@ -84,54 +84,6 @@ func (h *Handler) joinSession(w http.ResponseWriter, r *http.Request) {
 	respond(w, http.StatusCreated, player)
 }
 
-// addContactPlayer lets an admin pre-add a contact by user_id as a player.
-// The player name and user_id are taken from the contact's account.
-func (h *Handler) addContactPlayer(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-
-	var body struct {
-		ContactUserID string `json:"contact_user_id"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ContactUserID == "" {
-		respondError(w, http.StatusBadRequest, "contact_user_id is required")
-		return
-	}
-
-	sess, err := h.store.GetSession(id)
-	if errors.Is(err, store.ErrNotFound) {
-		respondError(w, http.StatusNotFound, "session not found")
-		return
-	}
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, "could not load session")
-		return
-	}
-	if !isAdmin(extractAdminToken(r), sess.AdminToken) {
-		respondError(w, http.StatusForbidden, "admin access required")
-		return
-	}
-	if sess.Status != domain.StatusLobby {
-		respondError(w, http.StatusConflict, "session has already started")
-		return
-	}
-
-	player, err := h.store.AddContactPlayer(id, body.ContactUserID)
-	if errors.Is(err, store.ErrNotFound) {
-		respondError(w, http.StatusNotFound, "user not found")
-		return
-	}
-	if err != nil {
-		if isUniqueConstraintError(err) {
-			respondError(w, http.StatusConflict, "player already in session")
-			return
-		}
-		respondError(w, http.StatusInternalServerError, "could not add player")
-		return
-	}
-
-	respond(w, http.StatusCreated, player)
-}
-
 func (h *Handler) deactivatePlayer(w http.ResponseWriter, r *http.Request) {
 	sessionID := chi.URLParam(r, "id")
 	playerID := chi.URLParam(r, "playerID")

--- a/internal/store/contacts.go
+++ b/internal/store/contacts.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"database/sql"
 	"errors"
 	"time"
 
@@ -122,18 +121,6 @@ func (s *Store) SearchUsers(userID, query string) ([]domain.UserSearchResult, er
 	return results, rows.Err()
 }
 
-// IsContact returns true if contact_user_id is in user_id's contacts.
-func (s *Store) IsContact(userID, contactUserID string) (bool, error) {
-	var count int
-	err := s.db.QueryRow(
-		`SELECT COUNT(*) FROM contacts WHERE user_id = ? AND contact_user_id = ?`,
-		userID, contactUserID,
-	).Scan(&count)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	return count > 0, err
-}
 
 // AddContactPlayer looks up the contact user's display name and creates a player
 // record in the session linked to their user account. Returns ErrNotFound if the

--- a/internal/store/contacts_test.go
+++ b/internal/store/contacts_test.go
@@ -181,20 +181,3 @@ func TestSearchUsers_MarksContacts(t *testing.T) {
 	}
 }
 
-func TestIsContact(t *testing.T) {
-	s := newTestStore(t)
-	alice := createUser(t, s, "alice@example.com", "Alice")
-	bob := createUser(t, s, "bob@example.com", "Bob")
-
-	ok, _ := s.IsContact(alice, bob)
-	if ok {
-		t.Error("expected false before adding contact")
-	}
-
-	s.AddContact(alice, bob)
-
-	ok, _ = s.IsContact(alice, bob)
-	if !ok {
-		t.Error("expected true after adding contact")
-	}
-}

--- a/internal/store/players.go
+++ b/internal/store/players.go
@@ -85,12 +85,3 @@ func scanPlayers(rows *sql.Rows) ([]domain.Player, error) {
 	return players, rows.Err()
 }
 
-func activePlayers(players []domain.Player) []domain.Player {
-	var out []domain.Player
-	for _, p := range players {
-		if p.Active {
-			out = append(out, p)
-		}
-	}
-	return out
-}


### PR DESCRIPTION
## Summary
Removes three unreachable functions identified by `deadcode`:

- `Handler.addContactPlayer` — superseded by the invite flow
- `Store.IsContact` — no longer called anywhere
- `activePlayers` in `store/players.go` — unused helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)