### PR TITLE
feat(scheduler): randomize player order on tournament start

### DIFF
--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 	"time"
@@ -127,6 +128,7 @@ func (h *Handler) startSession(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusUnprocessableEntity, "not enough players to start")
 			return
 		}
+		rand.Shuffle(len(active), func(i, j int) { active[i], active[j] = active[j], active[i] })
 		totalRounds := scheduler.TotalRounds(len(active), sess.Courts)
 		rounds := scheduler.Generate(active, sess.Courts, totalRounds)
 		if err := h.store.SaveRounds(id, rounds); err != nil {


### PR DESCRIPTION
## Summary
Shuffles active players before generating rounds so the first court/bench assignments are not always determined by join order (admin first, then others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)