### PR TITLE
fix(lobby): hide invite row when invited player joins

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,17 @@
 - [ ] Admin can add extra rounds mid-session if players want to keep playing
 - [ ] Round Robin game mode — every pair plays every other pair
 - [ ] Assign score entry to other players (not admin-only)
+- [ ] Pull-to-refresh on home screen and active session
+
+### Tooling & Infrastructure
+
+- [ ] **Error toasts** — wire up svelte-sonner (already installed) to API client for global error feedback
+- [ ] **Structured logging** — replace `log.Printf` with `log/slog` for queryable JSON logs on Fly.io
+- [ ] **Sentry** — add `@sentry/sveltekit` + Go SDK for production error tracking with stack traces
+- [ ] **API handler tests** — scheduler is well-tested; add coverage for critical API handlers (start session, submit score, advance round)
+- [ ] **Database migrations** — adopt `golang-migrate` or Atlas for versioned schema files instead of raw SQL in Go code
+- [ ] **sqlc** — generate type-safe Go from SQL queries, eliminate hand-written `rows.Scan` patterns in `internal/store/`
+- [ ] **Playwright** — E2E tests for happy path (create session → join → submit scores)
 
 ## In Progress
 

--- a/web/src/lib/components/Lobby.svelte
+++ b/web/src/lib/components/Lobby.svelte
@@ -48,6 +48,9 @@
     }
   });
 
+  const joinedUserIds = $derived(new Set(session.players.map(p => p.user_id).filter(Boolean)));
+  const pendingInvites = $derived(sessionInvites.filter(inv => !joinedUserIds.has(inv.to_user_id)));
+
   function onPlayerSearchInput() {
     clearTimeout(playerSearchDebounce);
     if (playerSearch.length < 2) { playerResults = []; playerSearchLoading = false; return; }
@@ -555,7 +558,7 @@
               </div>
             </div>
           {/each}
-          {#each sessionInvites as invite (invite.id)}
+          {#each pendingInvites as invite (invite.id)}
             <div class="flex items-center gap-3 px-4 py-3 opacity-60">
               <Avatar name={invite.to_display_name ?? '?'} size="sm" ring="ring-2 ring-[var(--primary)]/30" />
               <span class="flex-1 text-sm font-medium text-[var(--text-secondary)] truncate">{invite.to_display_name}</span>


### PR DESCRIPTION
## Summary

When an invited player accepts and joins the lobby, the host was seeing them in both the player list and the pending invites list simultaneously.

## Root cause

`sessionInvites` was only re-fetched on mount and when sending a new invite — never when the player list updated. So an accepted invite lingered until the host manually refreshed.

## Fix

Derive `pendingInvites` client-side by filtering out any invite whose `to_user_id` is already present in `session.players`. The moment the session refreshes and the new player appears, their invite row disappears automatically — no extra API call needed.

## Test plan

- [x] Invite a registered user to a lobby
- [x] Have them accept the invite and join
- [x] Verify they appear only once in the player list, not also in the pending invites

🤖 Generated with [Claude Code](https://claude.com/claude-code)