### PR TITLE
feat(ui): pull-to-refresh on home, session, and profile

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -93,3 +93,8 @@ h3 {
 .shake {
   animation: shake 0.4s ease;
 }
+
+@keyframes ptr-fade {
+  0%   { opacity: 1; }
+  100% { opacity: 0.1; }
+}

--- a/web/src/lib/components/PullToRefresh.svelte
+++ b/web/src/lib/components/PullToRefresh.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    onRefresh,
+    children
+  }: {
+    onRefresh: () => Promise<void>;
+    children: Snippet;
+  } = $props();
+
+  const THRESHOLD = 80;
+  const MAX_PULL = 120;
+
+  let dragStartY = 0;
+  let dragOffset = $state(0);
+  let dragging = $state(false);
+  let refreshing = $state(false);
+
+  function getScrollTop(): number {
+    return window.scrollY || document.documentElement.scrollTop || 0;
+  }
+
+  function onTouchStart(e: TouchEvent) {
+    if (getScrollTop() > 0) return;
+    dragStartY = e.touches[0].clientY;
+    dragging = true;
+    dragOffset = 0;
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (!dragging) return;
+    const delta = e.touches[0].clientY - dragStartY;
+    if (delta <= 0) { dragOffset = 0; return; }
+    if (getScrollTop() === 0 && delta > 0) e.preventDefault();
+    dragOffset = Math.min(MAX_PULL, delta);
+  }
+
+  async function onTouchEnd() {
+    if (!dragging) return;
+    dragging = false;
+    if (dragOffset >= THRESHOLD) {
+      refreshing = true;
+      dragOffset = 0;
+      try {
+        await Promise.all([onRefresh(), new Promise(r => setTimeout(r, 1000))]);
+      } finally {
+        refreshing = false;
+      }
+    } else {
+      dragOffset = 0;
+    }
+  }
+
+  // Non-passive touchmove to allow preventDefault (same pattern as Lobby.svelte)
+  function nonPassiveTouchMove(node: HTMLElement) {
+    node.addEventListener('touchmove', onTouchMove, { passive: false });
+    return { destroy() { node.removeEventListener('touchmove', onTouchMove); } };
+  }
+
+  let progress = $derived(Math.min(1, dragOffset / THRESHOLD));
+  let arrowRotation = $derived(Math.min(180, progress * 180));
+</script>
+
+<div
+  class="relative min-h-full"
+  role="region"
+  aria-label="Pull to refresh"
+  ontouchstart={onTouchStart}
+  ontouchend={onTouchEnd}
+  use:nonPassiveTouchMove
+>
+  <!-- Indicator -->
+  <div
+    class="flex items-center justify-center overflow-hidden text-[var(--text-disabled)] transition-[height,opacity] duration-200 ease-out"
+    style="height: {dragOffset > 0 || refreshing ? (refreshing ? 48 : dragOffset) : 0}px; opacity: {refreshing ? 1 : progress};"
+  >
+    {#if refreshing}
+      <!-- Dotted spinner: 8 dots arranged in a circle, staggered opacity -->
+      <div class="relative size-7" aria-label="Loading">
+        {#each Array(8) as _, i}
+          {@const size = 4 - i * 0.35}
+          <div
+            class="absolute rounded-full bg-current"
+            style="
+              width: {size}px;
+              height: {size}px;
+              top: 0;
+              left: 50%;
+              margin-left: -{size / 2}px;
+              transform-origin: {size / 2}px 14px;
+              transform: rotate({i * 45}deg);
+              animation: ptr-fade 0.8s linear infinite;
+              animation-delay: {(8 - i) * -0.1}s;
+              opacity: {1 - i * 0.1};
+            "
+          ></div>
+        {/each}
+      </div>
+    {:else}
+      <!-- Pull arrow, rotates as you drag -->
+      <svg
+        style="transform: rotate({arrowRotation}deg); transition: transform 0.15s ease;"
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <line x1="12" y1="5" x2="12" y2="19" />
+        <polyline points="19 12 12 19 5 12" />
+      </svg>
+    {/if}
+  </div>
+
+  <!-- Content pushed down while pulling -->
+  <div
+    class="will-change-transform"
+    style="transform: translateY({dragOffset}px); transition: {dragging ? 'none' : 'transform 0.2s ease'};"
+  >
+    {@render children()}
+  </div>
+</div>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -7,6 +7,7 @@
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import Footer from '$lib/components/Footer.svelte';
+  import PullToRefresh from '$lib/components/PullToRefresh.svelte';
   import { _ } from 'svelte-i18n';
   import { initials } from '$lib/utils';
   import { fly } from 'svelte/transition';
@@ -41,6 +42,24 @@
   let showDeletedBanner = $state(false);
   let showNotFoundBanner = $state(false);
 
+  async function loadRejoin() {
+    const lastId = localStorage.getItem('last_session_id');
+    if (!lastId) { rejoinSession = null; return; }
+    try {
+      const token = localStorage.getItem(`admin_token_${lastId}`) ?? undefined;
+      const s = await api.sessions.get(lastId, token);
+      if (s.status === 'lobby' || s.status === 'active') {
+        rejoinSession = s;
+        rejoinHref = token ? `/s/${lastId}?token=${token}` : `/s/${lastId}`;
+      } else {
+        rejoinSession = null;
+      }
+    } catch {
+      localStorage.removeItem('last_session_id');
+      rejoinSession = null;
+    }
+  }
+
   onMount(async () => {
     // If ?create=1, go straight to setup (used by profile "New tournament" link)
     if (page.url.searchParams.get('create') === '1') {
@@ -56,20 +75,7 @@
       setTimeout(() => { showNotFoundBanner = false; }, 5000);
     }
 
-    // Load rejoin session in parallel with auth check
-    const lastId = localStorage.getItem('last_session_id');
-    if (lastId) {
-      try {
-        const token = localStorage.getItem(`admin_token_${lastId}`) ?? undefined;
-        const s = await api.sessions.get(lastId, token);
-        if (s.status === 'lobby' || s.status === 'active') {
-          rejoinSession = s;
-          rejoinHref = token ? `/s/${lastId}?token=${token}` : `/s/${lastId}`;
-        }
-      } catch {
-        localStorage.removeItem('last_session_id');
-      }
-    }
+    await loadRejoin();
   });
 
   // Redirect logged-in users to profile
@@ -123,6 +129,7 @@
       {$_('home_session_not_found')}
     </div>
   {/if}
+  <PullToRefresh onRefresh={loadRejoin}>
   <main class="flex min-h-svh flex-col items-center px-6 py-12" class:pt-16={showDeletedBanner || showNotFoundBanner}>
   <div class="flex w-full max-w-sm flex-1 flex-col">
     <div class="flex flex-1 flex-col justify-center space-y-12">
@@ -211,6 +218,7 @@
   </div>
   <Footer />
   </main>
+  </PullToRefresh>
 
 {:else}
   <main class="flex min-h-svh flex-col items-center px-6 py-6">

--- a/web/src/routes/profile/+page.svelte
+++ b/web/src/routes/profile/+page.svelte
@@ -8,6 +8,7 @@
   import { CalendarDays, Radio, ChevronDown, UserPlus, X, Search, Check } from 'lucide-svelte';
   import Footer from '$lib/components/Footer.svelte';
   import CreateDrawer from '$lib/components/CreateDrawer.svelte';
+  import PullToRefresh from '$lib/components/PullToRefresh.svelte';
   import Avatar from '$lib/components/ui/Avatar.svelte';
   import { fly, slide } from 'svelte/transition';
   import { subscribeToPush, unsubscribeFromPush } from '$lib/push';
@@ -133,15 +134,8 @@
     }
   }
 
-  onMount(async () => {
-    if (!auth.token) { goto('/auth'); return; }
-    if (page.url.searchParams.get('notfound') === '1') {
-      showNotFoundBanner = true;
-      setTimeout(() => { showNotFoundBanner = false; }, 4000);
-    }
-    if (page.url.searchParams.get('create') === '1') {
-      showCreateDrawer = true;
-    }
+  async function load() {
+    if (!auth.token) return;
     try {
       const [profileRes, historyRes, contactsRes, invitesRes] = await Promise.all([
         api.auth.profile(auth.token),
@@ -165,6 +159,18 @@
     } finally {
       loading = false;
     }
+  }
+
+  onMount(async () => {
+    if (!auth.token) { goto('/auth'); return; }
+    if (page.url.searchParams.get('notfound') === '1') {
+      showNotFoundBanner = true;
+      setTimeout(() => { showNotFoundBanner = false; }, 4000);
+    }
+    if (page.url.searchParams.get('create') === '1') {
+      showCreateDrawer = true;
+    }
+    await load();
 
     // Install detection — runs immediately, no SW needed
     isStandalone = window.matchMedia('(display-mode: standalone)').matches
@@ -278,6 +284,7 @@
   </div>
 {/if}
 
+<PullToRefresh onRefresh={load}>
 <main class="mx-auto max-w-[480px] px-6 pb-10 pt-8 space-y-8">
 
   <!-- Header -->
@@ -661,6 +668,7 @@
   <Footer />
 
 </main>
+</PullToRefresh>
 
 <CreateDrawer bind:open={showCreateDrawer} />
 

--- a/web/src/routes/s/[id]/+page.svelte
+++ b/web/src/routes/s/[id]/+page.svelte
@@ -8,6 +8,7 @@
   import TennisMatch from '$lib/components/TennisMatch.svelte';
   import Leaderboard from '$lib/components/Leaderboard.svelte';
   import TennisResult from '$lib/components/TennisResult.svelte';
+  import PullToRefresh from '$lib/components/PullToRefresh.svelte';
 
   let session = $state<App.Session | null>(null);
   let currentRound = $state<App.Round | null>(null);
@@ -67,11 +68,17 @@
     <p class="text-sm text-[var(--text-secondary)]">Loading…</p>
   </main>
 {:else if session.status === 'lobby'}
-  <Lobby {session} {isAdmin} onRefresh={load} onStarted={load} />
+  <PullToRefresh onRefresh={load}>
+    <Lobby {session} {isAdmin} onRefresh={load} onStarted={load} />
+  </PullToRefresh>
 {:else if session.status === 'active' && session.game_mode === 'tennis'}
-  <TennisMatch {session} {isAdmin} onRefresh={load} />
+  <PullToRefresh onRefresh={load}>
+    <TennisMatch {session} {isAdmin} onRefresh={load} />
+  </PullToRefresh>
 {:else if session.status === 'active' && currentRound}
-  <ActiveSession {session} {currentRound} {isAdmin} onRefresh={load} />
+  <PullToRefresh onRefresh={load}>
+    <ActiveSession {session} {currentRound} {isAdmin} onRefresh={load} />
+  </PullToRefresh>
 {:else if session.status === 'complete' && session.game_mode === 'tennis'}
   <TennisResult {session} />
 {:else if session.status === 'complete'}


### PR DESCRIPTION
## Summary

- New reusable `PullToRefresh.svelte` component — drag down from top triggers a data reload
- Dotted spinner with 8 dots: clockwise rotation, tapering size and opacity from front to tail, 1s minimum display time
- Applied to home screen (rejoin link), session page (lobby, active Americano/Mexicano, Tennis), and profile page (stats, history, contacts, invites)
- `@keyframes ptr-fade` added to `app.css`; no `<style>` block in the component — all Tailwind

## Test plan

- [x] Open app on mobile or Chrome DevTools mobile emulation
- [x] Home screen: drag down → arrow appears → release past threshold → spinner shows ≥1s → rejoin link updates
- [x] Session lobby: drag down → refresh triggers
- [x] Active session: drag down → current round reloads immediately
- [x] Profile: drag down → stats/history/invites reload
- [x] Dragging less than 80px snaps back without refreshing
- [x] No conflict with lobby player drag-to-assign gesture

🤖 Generated with [Claude Code](https://claude.com/claude-code)