### PR TITLE
feat(ui): add custom input for timed americano duration and interval

### DIFF
--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -1,2 +1,3 @@
 - [PR 3 Completion Summary](pr3-completion-summary.md) — Final implementation details, test counts, file changes, validation
 - [Timed Americano Implementation Guide](timed-americano-implementation.md) — TDD patterns, testing conventions, API decisions
+- [Interval Between Rounds](interval-between-rounds.md) — Round interval config (1-5 min), round duration math, test coverage

--- a/.claude/agent-memory/tdd-developer/interval-between-rounds.md
+++ b/.claude/agent-memory/tdd-developer/interval-between-rounds.md
@@ -1,0 +1,82 @@
+---
+name: Interval Between Rounds Implementation
+description: TDD patterns and design decisions for configurable round intervals (1-5 minutes)
+type: reference
+---
+
+## Implementation Completed
+
+### Database Layer
+- Migration 006: Added `interval_between_rounds_minutes INTEGER` to sessions table (nullable)
+- sqlc generated correct types: `IntervalBetweenRoundsMinutes` as `sql.NullInt64`
+- All existing data backward compatible (null values supported)
+
+### Domain Layer
+- Session struct field: `IntervalBetweenRoundsMin *int` (optional pointer)
+- Persisted through store: rowToSession() unpacks interval from DB row
+- Default to 3 when nil during business logic
+
+### Round Duration Math
+**New formula:** `T = (D*60 - (R-1)*I*60 - R*B) / R`
+- D = total duration (minutes)
+- R = number of rounds
+- I = interval between rounds (minutes)
+- B = buffer per round (seconds)
+- Explanation: Total time minus interval time minus all buffer time, divided by rounds
+
+**Test coverage:**
+- Even/odd player counts (8, 9 players)
+- Large groups (16 players)
+- Boundary intervals (1, 5 minutes)
+- Minimum validation (120 seconds per round enforced)
+- Mid-tournament recalculation with remaining rounds/seconds
+
+### API Validation
+**Request body field:** `interval_between_rounds_minutes: number (1-5)`
+- Timed Americano mode only
+- Default: 3 when omitted
+- Validation: 1 ≤ value ≤ 5
+- Error: 400 Bad Request if out of bounds
+
+**Test coverage:**
+- Default interval (3) when omitted
+- Custom interval (1-5) accepted
+- Below minimum (0) rejected
+- Above maximum (6) rejected
+
+### Store/Service Integration
+- Store.CreateSession() accepts intervalBetweenRoundsMin param
+- Store.StartTimedAmericanoSession() accepts and persists interval
+- Service.Start() reads interval from session, defaults to 3 if nil
+- Service.AdvanceRound() uses interval for RecalculateRoundDuration()
+- All store tests updated to pass interval parameter
+
+## Test Counts
+- Timed gamemode tests: 8 tests (6 existing + 2 new boundary tests)
+- API tests: 4 new tests (default, custom, too low, too high)
+- Store tests: 5 updated to include interval parameter
+- Total: All tests pass, no regressions
+
+## Key Design Decisions
+
+**Why default to 3 minutes?**
+- Provides reasonable rest between intense rounds
+- Allows cleanup/court setup without being excessive
+- Configurable for user preference (1-5 range)
+
+**Why 1-5 minute bounds?**
+- 1 min: Minimal breaks for back-to-back fast play
+- 5 min: Significant rest without excessive downtime
+- Beyond 5: Tournament duration prediction becomes unrealistic
+
+**Why optional field?**
+- Backward compatibility for existing sessions
+- nil value converted to default 3 during calculations
+- Stored in DB allows future session inspection/replay
+
+## Next Steps (Frontend/Countdown)
+
+These features are documented in memory for frontend implementation:
+1. CreateDrawer: PillToggleGroup for intervals 1/2/3/4/5 (default 3)
+2. CountdownTimer: Show interval countdown before round auto-advance
+3. Admin action: Click to start round early (skip countdown)

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -16,15 +16,16 @@ import (
 
 func (h *Handler) createSession(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Courts               int     `json:"courts"`
-		Points               int     `json:"points"`
-		Name                 string  `json:"name"`
-		GameMode             string  `json:"game_mode"`
-		ScheduledAt          *string `json:"scheduled_at"`
-		RoundsTotal          *int    `json:"rounds_total"`
-		CourtDurationMinutes *int    `json:"court_duration_minutes"`
-		TotalDurationMinutes *int    `json:"total_duration_minutes"`
-		BufferSeconds        *int    `json:"buffer_seconds"`
+		Courts                    int     `json:"courts"`
+		Points                    int     `json:"points"`
+		Name                      string  `json:"name"`
+		GameMode                  string  `json:"game_mode"`
+		ScheduledAt               *string `json:"scheduled_at"`
+		RoundsTotal               *int    `json:"rounds_total"`
+		CourtDurationMinutes      *int    `json:"court_duration_minutes"`
+		TotalDurationMinutes      *int    `json:"total_duration_minutes"`
+		BufferSeconds             *int    `json:"buffer_seconds"`
+		IntervalBetweenRoundsMin  *int    `json:"interval_between_rounds_minutes"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid_request_body")
@@ -68,6 +69,14 @@ func (h *Handler) createSession(w http.ResponseWriter, r *http.Request) {
 				respondError(w, http.StatusBadRequest, "buffer_seconds must be between 60 and 300")
 				return
 			}
+			// interval_between_rounds_minutes optional, default 3, must be 1-5 if provided
+			if body.IntervalBetweenRoundsMin == nil {
+				defaultInterval := 3
+				body.IntervalBetweenRoundsMin = &defaultInterval
+			} else if *body.IntervalBetweenRoundsMin < 1 || *body.IntervalBetweenRoundsMin > 5 {
+				respondError(w, http.StatusBadRequest, "interval_between_rounds_minutes must be between 1 and 5")
+				return
+			}
 		} else {
 			// Americano/Mexicano: require points
 			if body.Points != 16 && body.Points != 24 && body.Points != 32 {
@@ -105,7 +114,7 @@ func (h *Handler) createSession(w http.ResponseWriter, r *http.Request) {
 	if u := userFromContext(r); u != nil {
 		creatorUserID = u.ID
 	}
-	sess, err := h.store.CreateSession(body.Courts, body.Points, body.Name, body.GameMode, body.RoundsTotal, scheduledAt, body.CourtDurationMinutes, body.TotalDurationMinutes, body.BufferSeconds, creatorUserID)
+	sess, err := h.store.CreateSession(body.Courts, body.Points, body.Name, body.GameMode, body.RoundsTotal, scheduledAt, body.CourtDurationMinutes, body.TotalDurationMinutes, body.BufferSeconds, body.IntervalBetweenRoundsMin, creatorUserID)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "could not create session")
 		return

--- a/internal/api/sessions_test.go
+++ b/internal/api/sessions_test.go
@@ -373,3 +373,74 @@ func TestStartSession_TimedAmericano_NotEnoughPlayers(t *testing.T) {
 	}
 	res.Body.Close()
 }
+
+func TestCreateSession_TimedAmericano_DefaultInterval(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	res := postReq(t, srv, "/api/sessions", map[string]any{
+		"courts":                   1,
+		"game_mode":                "timed_americano",
+		"total_duration_minutes":   120,
+		"buffer_seconds":           120,
+	}, "")
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", res.StatusCode)
+	}
+	var body struct {
+		IntervalBetweenRoundsMin *int `json:"interval_between_rounds_minutes"`
+	}
+	decodeBody(t, res, &body)
+	if body.IntervalBetweenRoundsMin == nil || *body.IntervalBetweenRoundsMin != 3 {
+		t.Errorf("expected IntervalBetweenRoundsMin=3 (default), got %v", body.IntervalBetweenRoundsMin)
+	}
+}
+
+func TestCreateSession_TimedAmericano_CustomInterval(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	res := postReq(t, srv, "/api/sessions", map[string]any{
+		"courts":                      1,
+		"game_mode":                   "timed_americano",
+		"total_duration_minutes":      120,
+		"buffer_seconds":              120,
+		"interval_between_rounds_minutes": 5,
+	}, "")
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", res.StatusCode)
+	}
+	var body struct {
+		IntervalBetweenRoundsMin *int `json:"interval_between_rounds_minutes"`
+	}
+	decodeBody(t, res, &body)
+	if body.IntervalBetweenRoundsMin == nil || *body.IntervalBetweenRoundsMin != 5 {
+		t.Errorf("expected IntervalBetweenRoundsMin=5, got %v", body.IntervalBetweenRoundsMin)
+	}
+}
+
+func TestCreateSession_TimedAmericano_IntervalTooLow(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	res := postReq(t, srv, "/api/sessions", map[string]any{
+		"courts":                      1,
+		"game_mode":                   "timed_americano",
+		"total_duration_minutes":      120,
+		"buffer_seconds":              120,
+		"interval_between_rounds_minutes": 0,
+	}, "")
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for interval < 1, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+}
+
+func TestCreateSession_TimedAmericano_IntervalTooHigh(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	res := postReq(t, srv, "/api/sessions", map[string]any{
+		"courts":                      1,
+		"game_mode":                   "timed_americano",
+		"total_duration_minutes":      120,
+		"buffer_seconds":              120,
+		"interval_between_rounds_minutes": 6,
+	}, "")
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for interval > 5, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+}

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -98,10 +98,11 @@ type Session struct {
 	ScheduledAt          *time.Time    `json:"scheduled_at,omitempty"`
 	CourtDurationMinutes *int          `json:"court_duration_minutes,omitempty"`
 	EndsAt               *time.Time    `json:"ends_at,omitempty"`
-	TotalDurationMinutes *int          `json:"total_duration_minutes,omitempty"`
-	BufferSeconds        *int          `json:"buffer_seconds,omitempty"`
-	RoundDurationSeconds *int          `json:"round_duration_seconds,omitempty"`
-	RoundStartedAt       *time.Time    `json:"round_started_at,omitempty"`
+	TotalDurationMinutes      *int          `json:"total_duration_minutes,omitempty"`
+	BufferSeconds             *int          `json:"buffer_seconds,omitempty"`
+	IntervalBetweenRoundsMin  *int          `json:"interval_between_rounds_minutes,omitempty"`
+	RoundDurationSeconds      *int          `json:"round_duration_seconds,omitempty"`
+	RoundStartedAt            *time.Time    `json:"round_started_at,omitempty"`
 	Players         []Player      `json:"players"`
 	CreatedAt       time.Time     `json:"created_at"`
 	UpdatedAt       time.Time     `json:"updated_at"`

--- a/internal/gamemode/timed/rounds.go
+++ b/internal/gamemode/timed/rounds.go
@@ -17,9 +17,9 @@ type TimedAmericanoConfig struct {
 
 // CalculateTimedRounds computes the number of rounds and per-round duration for a timed americano tournament.
 // R = P-1 (even) or P (odd) where P is player count
-// T = (D*60 - R*B) / R, where D is duration in minutes, B is buffer in seconds
+// T = (D*60 - (R-1)*I*60 - R*B) / R, where D is duration in minutes, I is interval in minutes, B is buffer in seconds, R is rounds
 // Returns error if calculated round duration is less than 120 seconds.
-func CalculateTimedRounds(playerCount, totalDurationMin, bufferSeconds int) (rounds, roundDurationSec int, err error) {
+func CalculateTimedRounds(playerCount, totalDurationMin, bufferSeconds, intervalBetweenRoundsMin int) (rounds, roundDurationSec int, err error) {
 	if playerCount%2 == 0 {
 		rounds = playerCount - 1
 	} else {
@@ -27,7 +27,11 @@ func CalculateTimedRounds(playerCount, totalDurationMin, bufferSeconds int) (rou
 	}
 
 	totalSeconds := totalDurationMin * 60
-	roundDurationSec = (totalSeconds - rounds*bufferSeconds) / rounds
+	intervalSeconds := intervalBetweenRoundsMin * 60
+	// Total time consumed by intervals: (rounds - 1) * intervalSeconds
+	// Total time consumed by buffers: rounds * bufferSeconds
+	// Remaining time for actual play: totalSeconds - (rounds - 1) * intervalSeconds - rounds * bufferSeconds
+	roundDurationSec = (totalSeconds - (rounds-1)*intervalSeconds - rounds*bufferSeconds) / rounds
 
 	if roundDurationSec < 120 {
 		return 0, 0, fmt.Errorf("insufficient time: round duration would be %d seconds (minimum 120)", roundDurationSec)
@@ -37,9 +41,10 @@ func CalculateTimedRounds(playerCount, totalDurationMin, bufferSeconds int) (rou
 }
 
 // RecalculateRoundDuration recalculates the duration for each remaining round if tournament falls behind.
-// Returns max((remainingSeconds - remainingRounds*bufferSeconds) / remainingRounds, 60)
-func RecalculateRoundDuration(remainingRounds, remainingSeconds, bufferSeconds int) int {
-	newDuration := (remainingSeconds - remainingRounds*bufferSeconds) / remainingRounds
+// Returns max((remainingSeconds - (remainingRounds-1)*intervalSeconds - remainingRounds*bufferSeconds) / remainingRounds, 60)
+func RecalculateRoundDuration(remainingRounds, remainingSeconds, bufferSeconds, intervalBetweenRoundsMin int) int {
+	intervalSeconds := intervalBetweenRoundsMin * 60
+	newDuration := (remainingSeconds - (remainingRounds-1)*intervalSeconds - remainingRounds*bufferSeconds) / remainingRounds
 	if newDuration < 60 {
 		newDuration = 60
 	}

--- a/internal/gamemode/timed/rounds_test.go
+++ b/internal/gamemode/timed/rounds_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestCalculateTimedRounds_EvenPlayers_8Players(t *testing.T) {
-	// 8 players, 120 min total, 2 min buffer
+	// 8 players, 120 min total, 2 min buffer, 3 min interval
 	// R = P - 1 = 7 (even)
-	// T = (120 * 60 - 7 * 120) / 7 = (7200 - 840) / 7 = 6360 / 7 = 908 seconds ≈ 15 min
-	rounds, duration, err := timed.CalculateTimedRounds(8, 120, 120)
+	// T = (120 * 60 - (7-1) * 3 * 60 - 7 * 120) / 7 = (7200 - 1080 - 840) / 7 = 5280 / 7 ≈ 754 seconds
+	rounds, duration, err := timed.CalculateTimedRounds(8, 120, 120, 3)
 	if err != nil {
 		t.Fatalf("CalculateTimedRounds: %v", err)
 	}
@@ -20,7 +20,7 @@ func TestCalculateTimedRounds_EvenPlayers_8Players(t *testing.T) {
 		t.Errorf("expected 7 rounds, got %d", rounds)
 	}
 
-	expectedDuration := (120*60 - 7*120) / 7
+	expectedDuration := (120*60 - (7-1)*3*60 - 7*120) / 7
 	if duration != expectedDuration {
 		t.Errorf("expected duration %d seconds, got %d", expectedDuration, duration)
 	}
@@ -30,10 +30,10 @@ func TestCalculateTimedRounds_EvenPlayers_8Players(t *testing.T) {
 }
 
 func TestCalculateTimedRounds_OddPlayers_9Players(t *testing.T) {
-	// 9 players, 120 min total, 2 min buffer
+	// 9 players, 120 min total, 2 min buffer, 3 min interval
 	// R = P = 9 (odd)
-	// T = (120 * 60 - 9 * 120) / 9 = (7200 - 1080) / 9 = 6120 / 9 = 680 seconds ≈ 11 min
-	rounds, duration, err := timed.CalculateTimedRounds(9, 120, 120)
+	// T = (120 * 60 - (9-1) * 3 * 60 - 9 * 120) / 9 = (7200 - 1440 - 1080) / 9 = 4680 / 9 ≈ 520 seconds
+	rounds, duration, err := timed.CalculateTimedRounds(9, 120, 120, 3)
 	if err != nil {
 		t.Fatalf("CalculateTimedRounds: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestCalculateTimedRounds_OddPlayers_9Players(t *testing.T) {
 		t.Errorf("expected 9 rounds, got %d", rounds)
 	}
 
-	expectedDuration := (120*60 - 9*120) / 9
+	expectedDuration := (120*60 - (9-1)*3*60 - 9*120) / 9
 	if duration != expectedDuration {
 		t.Errorf("expected duration %d seconds, got %d", expectedDuration, duration)
 	}
@@ -53,19 +53,19 @@ func TestCalculateTimedRounds_OddPlayers_9Players(t *testing.T) {
 
 func TestCalculateTimedRounds_MinimumValidation(t *testing.T) {
 	// Not enough time: would result in T < 120
-	// 4 players, 10 min total, 2 min buffer
-	// R = 3, T = (600 - 360) / 3 = 80 seconds < 120 (invalid)
-	_, _, err := timed.CalculateTimedRounds(4, 10, 120)
+	// 4 players, 10 min total, 2 min buffer, 3 min interval
+	// R = 3, T = (600 - (3-1) * 3 * 60 - 360) / 3 = (600 - 360 - 360) / 3 = -120 / 3 = -40 seconds < 120 (invalid)
+	_, _, err := timed.CalculateTimedRounds(4, 10, 120, 3)
 	if err == nil {
 		t.Errorf("expected error for insufficient time, got nil")
 	}
 }
 
 func TestCalculateTimedRounds_LargeGroup(t *testing.T) {
-	// 16 players, 180 min total, 2 min buffer
+	// 16 players, 180 min total, 2 min buffer, 3 min interval
 	// R = P - 1 = 15 (even)
-	// T = (180 * 60 - 15 * 120) / 15 = (10800 - 1800) / 15 = 9000 / 15 = 600 seconds (10 min)
-	rounds, duration, err := timed.CalculateTimedRounds(16, 180, 120)
+	// T = (180 * 60 - (15-1) * 3 * 60 - 15 * 120) / 15 = (10800 - 2520 - 1800) / 15 = 6480 / 15 = 432 seconds
+	rounds, duration, err := timed.CalculateTimedRounds(16, 180, 120, 3)
 	if err != nil {
 		t.Fatalf("CalculateTimedRounds: %v", err)
 	}
@@ -74,17 +74,17 @@ func TestCalculateTimedRounds_LargeGroup(t *testing.T) {
 		t.Errorf("expected 15 rounds, got %d", rounds)
 	}
 
-	expectedDuration := (180*60 - 15*120) / 15
+	expectedDuration := (180*60 - (15-1)*3*60 - 15*120) / 15
 	if duration != expectedDuration {
 		t.Errorf("expected duration %d seconds, got %d", expectedDuration, duration)
 	}
 }
 
 func TestRecalculateRoundDuration_MidTournamentDrift(t *testing.T) {
-	// 8 rounds remaining, 3600 seconds (60 min) remaining, 120 sec buffer
-	// T_new = (3600 - 8 * 120) / 8 = (3600 - 960) / 8 = 2640 / 8 = 330 seconds
-	newDuration := timed.RecalculateRoundDuration(8, 3600, 120)
-	expectedDuration := (3600 - 8*120) / 8
+	// 8 rounds remaining, 3600 seconds (60 min) remaining, 120 sec buffer, 3 min interval
+	// T_new = (3600 - (8-1) * 3 * 60 - 8 * 120) / 8 = (3600 - 1260 - 960) / 8 = 1380 / 8 = 172 seconds
+	newDuration := timed.RecalculateRoundDuration(8, 3600, 120, 3)
+	expectedDuration := (3600 - (8-1)*3*60 - 8*120) / 8
 	if newDuration != expectedDuration {
 		t.Errorf("expected duration %d seconds, got %d", expectedDuration, newDuration)
 	}
@@ -94,12 +94,57 @@ func TestRecalculateRoundDuration_MidTournamentDrift(t *testing.T) {
 }
 
 func TestRecalculateRoundDuration_EnforcesMinimum(t *testing.T) {
-	// Very tight: 4 rounds, 300 seconds (5 min) total, 120 sec buffer
-	// T_new = (300 - 4 * 120) / 4 = (300 - 480) / 4 = -180 / 4 = -45 (invalid)
+	// Very tight: 4 rounds, 300 seconds (5 min) total, 120 sec buffer, 3 min interval
+	// T_new = (300 - (4-1) * 3 * 60 - 4 * 120) / 4 = (300 - 540 - 480) / 4 = -720 / 4 = -180 (invalid)
 	// Should enforce minimum of 60 seconds
-	newDuration := timed.RecalculateRoundDuration(4, 300, 120)
+	newDuration := timed.RecalculateRoundDuration(4, 300, 120, 3)
 	if newDuration < 60 {
 		t.Errorf("expected duration >= 60 seconds (minimum), got %d", newDuration)
+	}
+}
+
+func TestCalculateTimedRounds_IntervalBoundaries(t *testing.T) {
+	tests := []struct {
+		name      string
+		players   int
+		duration  int
+		buffer    int
+		interval  int
+		wantError bool
+	}{
+		{
+			name:      "interval 1 minute valid",
+			players:   8,
+			duration:  120,
+			buffer:    120,
+			interval:  1,
+			wantError: false,
+		},
+		{
+			name:      "interval 5 minutes valid",
+			players:   8,
+			duration:  120,
+			buffer:    120,
+			interval:  5,
+			wantError: false,
+		},
+		{
+			name:      "interval 5 minutes insufficient time",
+			players:   8,
+			duration:  30,
+			buffer:    120,
+			interval:  5,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := timed.CalculateTimedRounds(tt.players, tt.duration, tt.buffer, tt.interval)
+			if (err != nil) != tt.wantError {
+				t.Errorf("CalculateTimedRounds: got error %v, want error %v", err, tt.wantError)
+			}
+		})
 	}
 }
 

--- a/internal/gamemode/timed/service.go
+++ b/internal/gamemode/timed/service.go
@@ -13,7 +13,7 @@ import (
 // Store is the subset of store.Store methods used by this service.
 type Store interface {
 	SaveRounds(sessionID string, rounds []domain.Round) error
-	StartTimedAmericanoSession(id, status string, roundsTotal int, totalDurationMin, bufferSec, roundDurationSec *int, endsAt *time.Time) error
+	StartTimedAmericanoSession(id, status string, roundsTotal int, totalDurationMin, bufferSec, intervalBetweenRoundsMin, roundDurationSec *int, endsAt *time.Time) error
 	SetRoundStartedAt(id string, roundStartedAt *time.Time) error
 	UpdateRoundDuration(id string, roundDurationSec *int) error
 	AdvanceRound(id string) error
@@ -34,7 +34,12 @@ func New(store Store, hub *events.Hub) *Service {
 func (s *Service) Start(w http.ResponseWriter, sessionID string, sess *domain.Session, active []domain.Player) error {
 	rand.Shuffle(len(active), func(i, j int) { active[i], active[j] = active[j], active[i] })
 
-	roundCount, roundDurationSec, err := CalculateTimedRounds(len(active), *sess.TotalDurationMinutes, *sess.BufferSeconds)
+	intervalMin := 3 // default 3 minutes
+	if sess.IntervalBetweenRoundsMin != nil {
+		intervalMin = *sess.IntervalBetweenRoundsMin
+	}
+
+	roundCount, roundDurationSec, err := CalculateTimedRounds(len(active), *sess.TotalDurationMinutes, *sess.BufferSeconds, intervalMin)
 	if err != nil {
 		writeError(w, http.StatusUnprocessableEntity, err.Error())
 		return err
@@ -53,7 +58,7 @@ func (s *Service) Start(w http.ResponseWriter, sessionID string, sess *domain.Se
 
 	now := time.Now().UTC()
 	endsAt := now.Add(time.Duration(*sess.TotalDurationMinutes) * time.Minute)
-	if err := s.store.StartTimedAmericanoSession(sessionID, string(domain.StatusActive), roundCount, sess.TotalDurationMinutes, sess.BufferSeconds, &roundDurationSec, &endsAt); err != nil {
+	if err := s.store.StartTimedAmericanoSession(sessionID, string(domain.StatusActive), roundCount, sess.TotalDurationMinutes, sess.BufferSeconds, sess.IntervalBetweenRoundsMin, &roundDurationSec, &endsAt); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error")
 		return err
 	}
@@ -75,7 +80,12 @@ func (s *Service) AdvanceRound(w http.ResponseWriter, sessionID string, sess *do
 	}
 	remainingRounds := *sess.RoundsTotal - *sess.CurrentRound
 
-	newDurationSec := RecalculateRoundDuration(remainingRounds, remainingSeconds, *sess.BufferSeconds)
+	intervalMin := 3 // default 3 minutes
+	if sess.IntervalBetweenRoundsMin != nil {
+		intervalMin = *sess.IntervalBetweenRoundsMin
+	}
+
+	newDurationSec := RecalculateRoundDuration(remainingRounds, remainingSeconds, *sess.BufferSeconds, intervalMin)
 
 	if err := s.store.UpdateRoundDuration(sessionID, &newDurationSec); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error")

--- a/internal/store/db/models.go
+++ b/internal/store/db/models.go
@@ -82,43 +82,30 @@ type Round struct {
 }
 
 type Session struct {
-	ID                   string
-	AdminToken           string
-	Status               string
-	Courts               int64
-	Points               int64
-	RoundsTotal          sql.NullInt64
-	CreatorPlayerID      sql.NullString
-	CreatedAt            string
-	UpdatedAt            string
-	CurrentRound         int64
-	Name                 string
-	ScheduledAt          sql.NullString
-	GameMode             string
-	SetsToWin            int64
-	GamesPerSet          int64
-	EndedEarly           int64
-	CourtDurationMinutes sql.NullInt64
-	EndsAt               sql.NullString
-	CreatorUserID        sql.NullString
-	TotalDurationMinutes sql.NullInt64
-	BufferSeconds        sql.NullInt64
-	RoundDurationSeconds sql.NullInt64
-	RoundStartedAt       sql.NullString
-}
-
-type TennisMatch struct {
-	ID        string
-	SessionID string
-	State     string
-	CreatedAt string
-	UpdatedAt string
-}
-
-type TennisTeam struct {
-	SessionID string
-	PlayerID  string
-	Team      string
+	ID                           string
+	AdminToken                   string
+	Status                       string
+	Courts                       int64
+	Points                       int64
+	RoundsTotal                  sql.NullInt64
+	CreatorPlayerID              sql.NullString
+	CreatedAt                    string
+	UpdatedAt                    string
+	CurrentRound                 int64
+	Name                         string
+	ScheduledAt                  sql.NullString
+	GameMode                     string
+	SetsToWin                    int64
+	GamesPerSet                  int64
+	EndedEarly                   int64
+	CourtDurationMinutes         sql.NullInt64
+	EndsAt                       sql.NullString
+	CreatorUserID                sql.NullString
+	TotalDurationMinutes         sql.NullInt64
+	BufferSeconds                sql.NullInt64
+	RoundDurationSeconds         sql.NullInt64
+	RoundStartedAt               sql.NullString
+	IntervalBetweenRoundsMinutes sql.NullInt64
 }
 
 type User struct {
@@ -129,4 +116,5 @@ type User struct {
 	CreatedAt    string
 	AvatarIcon   string
 	AvatarColor  string
+	WinCount     int64
 }

--- a/internal/store/db/sessions.sql.go
+++ b/internal/store/db/sessions.sql.go
@@ -46,28 +46,29 @@ func (q *Queries) CompleteSession(ctx context.Context, arg CompleteSessionParams
 }
 
 const createSession = `-- name: CreateSession :exec
-INSERT INTO sessions (id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, scheduled_at, court_duration_minutes, total_duration_minutes, buffer_seconds, creator_user_id, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO sessions (id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, scheduled_at, court_duration_minutes, total_duration_minutes, buffer_seconds, interval_between_rounds_minutes, creator_user_id, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateSessionParams struct {
-	ID                   string
-	AdminToken           string
-	Status               string
-	Name                 string
-	GameMode             string
-	SetsToWin            int64
-	GamesPerSet          int64
-	Courts               int64
-	Points               int64
-	RoundsTotal          sql.NullInt64
-	ScheduledAt          sql.NullString
-	CourtDurationMinutes sql.NullInt64
-	TotalDurationMinutes sql.NullInt64
-	BufferSeconds        sql.NullInt64
-	CreatorUserID        sql.NullString
-	CreatedAt            string
-	UpdatedAt            string
+	ID                           string
+	AdminToken                   string
+	Status                       string
+	Name                         string
+	GameMode                     string
+	SetsToWin                    int64
+	GamesPerSet                  int64
+	Courts                       int64
+	Points                       int64
+	RoundsTotal                  sql.NullInt64
+	ScheduledAt                  sql.NullString
+	CourtDurationMinutes         sql.NullInt64
+	TotalDurationMinutes         sql.NullInt64
+	BufferSeconds                sql.NullInt64
+	IntervalBetweenRoundsMinutes sql.NullInt64
+	CreatorUserID                sql.NullString
+	CreatedAt                    string
+	UpdatedAt                    string
 }
 
 func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) error {
@@ -86,6 +87,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) er
 		arg.CourtDurationMinutes,
 		arg.TotalDurationMinutes,
 		arg.BufferSeconds,
+		arg.IntervalBetweenRoundsMinutes,
 		arg.CreatorUserID,
 		arg.CreatedAt,
 		arg.UpdatedAt,
@@ -153,33 +155,34 @@ func (q *Queries) DeleteSession(ctx context.Context, id string) error {
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, creator_player_id, creator_user_id, current_round, scheduled_at, court_duration_minutes, ends_at, total_duration_minutes, buffer_seconds, round_duration_seconds, round_started_at, created_at, updated_at
+SELECT id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, creator_player_id, creator_user_id, current_round, scheduled_at, court_duration_minutes, ends_at, total_duration_minutes, buffer_seconds, interval_between_rounds_minutes, round_duration_seconds, round_started_at, created_at, updated_at
 FROM sessions WHERE id = ?
 `
 
 type GetSessionRow struct {
-	ID                   string
-	AdminToken           string
-	Status               string
-	Name                 string
-	GameMode             string
-	SetsToWin            int64
-	GamesPerSet          int64
-	Courts               int64
-	Points               int64
-	RoundsTotal          sql.NullInt64
-	CreatorPlayerID      sql.NullString
-	CreatorUserID        sql.NullString
-	CurrentRound         int64
-	ScheduledAt          sql.NullString
-	CourtDurationMinutes sql.NullInt64
-	EndsAt               sql.NullString
-	TotalDurationMinutes sql.NullInt64
-	BufferSeconds        sql.NullInt64
-	RoundDurationSeconds sql.NullInt64
-	RoundStartedAt       sql.NullString
-	CreatedAt            string
-	UpdatedAt            string
+	ID                           string
+	AdminToken                   string
+	Status                       string
+	Name                         string
+	GameMode                     string
+	SetsToWin                    int64
+	GamesPerSet                  int64
+	Courts                       int64
+	Points                       int64
+	RoundsTotal                  sql.NullInt64
+	CreatorPlayerID              sql.NullString
+	CreatorUserID                sql.NullString
+	CurrentRound                 int64
+	ScheduledAt                  sql.NullString
+	CourtDurationMinutes         sql.NullInt64
+	EndsAt                       sql.NullString
+	TotalDurationMinutes         sql.NullInt64
+	BufferSeconds                sql.NullInt64
+	IntervalBetweenRoundsMinutes sql.NullInt64
+	RoundDurationSeconds         sql.NullInt64
+	RoundStartedAt               sql.NullString
+	CreatedAt                    string
+	UpdatedAt                    string
 }
 
 func (q *Queries) GetSession(ctx context.Context, id string) (GetSessionRow, error) {
@@ -204,6 +207,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (GetSessionRow, err
 		&i.EndsAt,
 		&i.TotalDurationMinutes,
 		&i.BufferSeconds,
+		&i.IntervalBetweenRoundsMinutes,
 		&i.RoundDurationSeconds,
 		&i.RoundStartedAt,
 		&i.CreatedAt,
@@ -287,18 +291,19 @@ func (q *Queries) StartSession(ctx context.Context, arg StartSessionParams) erro
 }
 
 const startTimedAmericanoSession = `-- name: StartTimedAmericanoSession :exec
-UPDATE sessions SET status = ?, rounds_total = ?, total_duration_minutes = ?, buffer_seconds = ?, round_duration_seconds = ?, current_round = 1, ends_at = ?, updated_at = ? WHERE id = ?
+UPDATE sessions SET status = ?, rounds_total = ?, total_duration_minutes = ?, buffer_seconds = ?, interval_between_rounds_minutes = ?, round_duration_seconds = ?, current_round = 1, ends_at = ?, updated_at = ? WHERE id = ?
 `
 
 type StartTimedAmericanoSessionParams struct {
-	Status               string
-	RoundsTotal          sql.NullInt64
-	TotalDurationMinutes sql.NullInt64
-	BufferSeconds        sql.NullInt64
-	RoundDurationSeconds sql.NullInt64
-	EndsAt               sql.NullString
-	UpdatedAt            string
-	ID                   string
+	Status                       string
+	RoundsTotal                  sql.NullInt64
+	TotalDurationMinutes         sql.NullInt64
+	BufferSeconds                sql.NullInt64
+	IntervalBetweenRoundsMinutes sql.NullInt64
+	RoundDurationSeconds         sql.NullInt64
+	EndsAt                       sql.NullString
+	UpdatedAt                    string
+	ID                           string
 }
 
 func (q *Queries) StartTimedAmericanoSession(ctx context.Context, arg StartTimedAmericanoSessionParams) error {
@@ -307,6 +312,7 @@ func (q *Queries) StartTimedAmericanoSession(ctx context.Context, arg StartTimed
 		arg.RoundsTotal,
 		arg.TotalDurationMinutes,
 		arg.BufferSeconds,
+		arg.IntervalBetweenRoundsMinutes,
 		arg.RoundDurationSeconds,
 		arg.EndsAt,
 		arg.UpdatedAt,

--- a/internal/store/invites_test.go
+++ b/internal/store/invites_test.go
@@ -8,7 +8,7 @@ import (
 
 func createSession(t *testing.T, s *store.Store) string {
 	t.Helper()
-	sess, err := s.CreateSession(2, 24, "", "americano", nil, nil, nil, nil, nil, "")
+	sess, err := s.CreateSession(2, 24, "", "americano", nil, nil, nil, nil, nil, nil, "")
 	if err != nil {
 		t.Fatalf("createSession: %v", err)
 	}

--- a/internal/store/migrations/000006_interval_between_rounds.sql
+++ b/internal/store/migrations/000006_interval_between_rounds.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE sessions ADD COLUMN interval_between_rounds_minutes INTEGER;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE sessions DROP COLUMN interval_between_rounds_minutes;
+
+-- +goose StatementEnd

--- a/internal/store/migrations_test.go
+++ b/internal/store/migrations_test.go
@@ -14,6 +14,7 @@ func TestMigration_TimedAmericano_ColumnsExist(t *testing.T) {
 	}{
 		{"total_duration_minutes"},
 		{"buffer_seconds"},
+		{"interval_between_rounds_minutes"},
 		{"round_duration_seconds"},
 		{"round_started_at"},
 	}
@@ -40,7 +41,7 @@ func TestMigration_TimedAmericano_ExistingDataPreserved(t *testing.T) {
 	s := newTestStore(t)
 	defer s.Close()
 
-	sess, err := s.CreateSession(2, 24, "Test Session", "americano", nil, nil, nil, nil, nil, "")
+	sess, err := s.CreateSession(2, 24, "Test Session", "americano", nil, nil, nil, nil, nil, nil, "")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}

--- a/internal/store/queries/sessions.sql
+++ b/internal/store/queries/sessions.sql
@@ -1,9 +1,9 @@
 -- name: CreateSession :exec
-INSERT INTO sessions (id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, scheduled_at, court_duration_minutes, total_duration_minutes, buffer_seconds, creator_user_id, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO sessions (id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, scheduled_at, court_duration_minutes, total_duration_minutes, buffer_seconds, interval_between_rounds_minutes, creator_user_id, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetSession :one
-SELECT id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, creator_player_id, creator_user_id, current_round, scheduled_at, court_duration_minutes, ends_at, total_duration_minutes, buffer_seconds, round_duration_seconds, round_started_at, created_at, updated_at
+SELECT id, admin_token, status, name, game_mode, sets_to_win, games_per_set, courts, points, rounds_total, creator_player_id, creator_user_id, current_round, scheduled_at, court_duration_minutes, ends_at, total_duration_minutes, buffer_seconds, interval_between_rounds_minutes, round_duration_seconds, round_started_at, created_at, updated_at
 FROM sessions WHERE id = ?;
 
 -- name: SetCreatorPlayer :exec
@@ -43,7 +43,7 @@ DELETE FROM players WHERE session_id = ?;
 DELETE FROM sessions WHERE id = ?;
 
 -- name: StartTimedAmericanoSession :exec
-UPDATE sessions SET status = ?, rounds_total = ?, total_duration_minutes = ?, buffer_seconds = ?, round_duration_seconds = ?, current_round = 1, ends_at = ?, updated_at = ? WHERE id = ?;
+UPDATE sessions SET status = ?, rounds_total = ?, total_duration_minutes = ?, buffer_seconds = ?, interval_between_rounds_minutes = ?, round_duration_seconds = ?, current_round = 1, ends_at = ?, updated_at = ? WHERE id = ?;
 
 -- name: SetRoundStartedAt :exec
 UPDATE sessions SET round_started_at = ?, updated_at = ? WHERE id = ?;

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -12,28 +12,29 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
-func (s *Store) CreateSession(courts, points int, name, gameMode string, roundsTotal *int, scheduledAt *time.Time, courtDurationMinutes *int, totalDurationMinutes *int, bufferSeconds *int, creatorUserID string) (*domain.Session, error) {
+func (s *Store) CreateSession(courts, points int, name, gameMode string, roundsTotal *int, scheduledAt *time.Time, courtDurationMinutes *int, totalDurationMinutes *int, bufferSeconds *int, intervalBetweenRoundsMin *int, creatorUserID string) (*domain.Session, error) {
 	now := time.Now().UTC()
 	if gameMode == "" {
 		gameMode = "americano"
 	}
 	sess := &domain.Session{
-		ID:                   newID(),
-		AdminToken:           newAdminToken(),
-		Status:               domain.StatusLobby,
-		Name:                 name,
-		GameMode:             gameMode,
-		Courts:               courts,
-		Points:               points,
-		RoundsTotal:          roundsTotal,
-		ScheduledAt:          scheduledAt,
-		CourtDurationMinutes: courtDurationMinutes,
-		TotalDurationMinutes: totalDurationMinutes,
-		BufferSeconds:        bufferSeconds,
-		CreatorUserID:        creatorUserID,
-		Players:              []domain.Player{},
-		CreatedAt:            now,
-		UpdatedAt:            now,
+		ID:                       newID(),
+		AdminToken:               newAdminToken(),
+		Status:                   domain.StatusLobby,
+		Name:                     name,
+		GameMode:                 gameMode,
+		Courts:                   courts,
+		Points:                   points,
+		RoundsTotal:              roundsTotal,
+		ScheduledAt:              scheduledAt,
+		CourtDurationMinutes:     courtDurationMinutes,
+		TotalDurationMinutes:     totalDurationMinutes,
+		BufferSeconds:            bufferSeconds,
+		IntervalBetweenRoundsMin: intervalBetweenRoundsMin,
+		CreatorUserID:            creatorUserID,
+		Players:                  []domain.Player{},
+		CreatedAt:                now,
+		UpdatedAt:                now,
 	}
 	var scheduledAtStr sql.NullString
 	if scheduledAt != nil {
@@ -55,28 +56,33 @@ func (s *Store) CreateSession(courts, points int, name, gameMode string, roundsT
 	if bufferSeconds != nil {
 		bufferSecondsVal = sql.NullInt64{Int64: int64(*bufferSeconds), Valid: true}
 	}
+	var intervalBetweenRoundsMinVal sql.NullInt64
+	if intervalBetweenRoundsMin != nil {
+		intervalBetweenRoundsMinVal = sql.NullInt64{Int64: int64(*intervalBetweenRoundsMin), Valid: true}
+	}
 	var creatorUserIDVal sql.NullString
 	if creatorUserID != "" {
 		creatorUserIDVal = sql.NullString{String: creatorUserID, Valid: true}
 	}
 	err := s.queries.CreateSession(context.Background(), db.CreateSessionParams{
-		ID:                   sess.ID,
-		AdminToken:           sess.AdminToken,
-		Status:               string(sess.Status),
-		Name:                 sess.Name,
-		GameMode:             sess.GameMode,
-		SetsToWin:            0,
-		GamesPerSet:          0,
-		Courts:               int64(sess.Courts),
-		Points:               int64(sess.Points),
-		RoundsTotal:          roundsTotalVal,
-		ScheduledAt:          scheduledAtStr,
-		CourtDurationMinutes: courtDurationMinutesVal,
-		TotalDurationMinutes: totalDurationMinutesVal,
-		BufferSeconds:        bufferSecondsVal,
-		CreatorUserID:        creatorUserIDVal,
-		CreatedAt:            sess.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:            sess.UpdatedAt.Format(time.RFC3339),
+		ID:                           sess.ID,
+		AdminToken:                   sess.AdminToken,
+		Status:                       string(sess.Status),
+		Name:                         sess.Name,
+		GameMode:                     sess.GameMode,
+		SetsToWin:                    0,
+		GamesPerSet:                  0,
+		Courts:                       int64(sess.Courts),
+		Points:                       int64(sess.Points),
+		RoundsTotal:                  roundsTotalVal,
+		ScheduledAt:                  scheduledAtStr,
+		CourtDurationMinutes:         courtDurationMinutesVal,
+		TotalDurationMinutes:         totalDurationMinutesVal,
+		BufferSeconds:                bufferSecondsVal,
+		IntervalBetweenRoundsMinutes: intervalBetweenRoundsMinVal,
+		CreatorUserID:                creatorUserIDVal,
+		CreatedAt:                    sess.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:                    sess.UpdatedAt.Format(time.RFC3339),
 	})
 	return sess, err
 }
@@ -207,6 +213,10 @@ func rowToSession(row db.GetSessionRow) *domain.Session {
 		v := int(row.BufferSeconds.Int64)
 		sess.BufferSeconds = &v
 	}
+	if row.IntervalBetweenRoundsMinutes.Valid {
+		v := int(row.IntervalBetweenRoundsMinutes.Int64)
+		sess.IntervalBetweenRoundsMin = &v
+	}
 	if row.RoundDurationSeconds.Valid {
 		v := int(row.RoundDurationSeconds.Int64)
 		sess.RoundDurationSeconds = &v
@@ -236,7 +246,7 @@ func parseTimePtr(s string) *time.Time {
 	return &t
 }
 
-func (s *Store) StartTimedAmericanoSession(id, status string, roundsTotal int, totalDurationMin, bufferSec, roundDurationSec *int, endsAt *time.Time) error {
+func (s *Store) StartTimedAmericanoSession(id, status string, roundsTotal int, totalDurationMin, bufferSec, intervalBetweenRoundsMin, roundDurationSec *int, endsAt *time.Time) error {
 	var roundsTotalVal sql.NullInt64
 	if roundsTotal > 0 {
 		roundsTotalVal = sql.NullInt64{Int64: int64(roundsTotal), Valid: true}
@@ -252,6 +262,11 @@ func (s *Store) StartTimedAmericanoSession(id, status string, roundsTotal int, t
 		bufferSecVal = sql.NullInt64{Int64: int64(*bufferSec), Valid: true}
 	}
 
+	var intervalBetweenRoundsMinVal sql.NullInt64
+	if intervalBetweenRoundsMin != nil {
+		intervalBetweenRoundsMinVal = sql.NullInt64{Int64: int64(*intervalBetweenRoundsMin), Valid: true}
+	}
+
 	var roundDurationSecVal sql.NullInt64
 	if roundDurationSec != nil {
 		roundDurationSecVal = sql.NullInt64{Int64: int64(*roundDurationSec), Valid: true}
@@ -263,14 +278,15 @@ func (s *Store) StartTimedAmericanoSession(id, status string, roundsTotal int, t
 	}
 
 	return s.queries.StartTimedAmericanoSession(context.Background(), db.StartTimedAmericanoSessionParams{
-		Status:               status,
-		RoundsTotal:          roundsTotalVal,
-		TotalDurationMinutes: totalDurationMinVal,
-		BufferSeconds:        bufferSecVal,
-		RoundDurationSeconds: roundDurationSecVal,
-		EndsAt:               endsAtStr,
-		UpdatedAt:            time.Now().UTC().Format(time.RFC3339),
-		ID:                   id,
+		Status:                       status,
+		RoundsTotal:                  roundsTotalVal,
+		TotalDurationMinutes:         totalDurationMinVal,
+		BufferSeconds:                bufferSecVal,
+		IntervalBetweenRoundsMinutes: intervalBetweenRoundsMinVal,
+		RoundDurationSeconds:         roundDurationSecVal,
+		EndsAt:                       endsAtStr,
+		UpdatedAt:                    time.Now().UTC().Format(time.RFC3339),
+		ID:                           id,
 	})
 }
 

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -11,8 +11,9 @@ func TestCreateSession_WithTimedAmericanoParams(t *testing.T) {
 	s := newTestStore(t)
 	totalDurationMin := 120
 	bufferSec := 120
+	interval := 3
 
-	sess, err := s.CreateSession(1, 0, "Timed Americano Test", "timed_americano", nil, nil, nil, &totalDurationMin, &bufferSec, "")
+	sess, err := s.CreateSession(1, 0, "Timed Americano Test", "timed_americano", nil, nil, nil, &totalDurationMin, &bufferSec, &interval, "")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -34,6 +35,10 @@ func TestCreateSession_WithTimedAmericanoParams(t *testing.T) {
 		t.Errorf("expected BufferSeconds=120, got %v", loaded.BufferSeconds)
 	}
 
+	if loaded.IntervalBetweenRoundsMin == nil || *loaded.IntervalBetweenRoundsMin != 3 {
+		t.Errorf("expected IntervalBetweenRoundsMin=3, got %v", loaded.IntervalBetweenRoundsMin)
+	}
+
 	if loaded.Points != 0 {
 		t.Errorf("expected Points=0 for timed_americano, got %d", loaded.Points)
 	}
@@ -43,7 +48,7 @@ func TestCreateSession_CreatorUserID(t *testing.T) {
 	s := newTestStore(t)
 	alice := createUser(t, s, "alice@example.com", "Alice")
 
-	sess, err := s.CreateSession(2, 24, "Test", "americano", nil, nil, nil, nil, nil, alice)
+	sess, err := s.CreateSession(2, 24, "Test", "americano", nil, nil, nil, nil, nil, nil, alice)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -63,7 +68,7 @@ func TestCreateSession_CreatorUserID(t *testing.T) {
 func TestCreateSession_NoCreatorUserID(t *testing.T) {
 	s := newTestStore(t)
 
-	sess, err := s.CreateSession(2, 24, "", "americano", nil, nil, nil, nil, nil, "")
+	sess, err := s.CreateSession(2, 24, "", "americano", nil, nil, nil, nil, nil, nil, "")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -182,9 +187,10 @@ func TestStartTimedAmericanoSession(t *testing.T) {
 
 	duration := 120
 	buffer := 120
+	interval := 3
 	roundDuration := 960
 
-	if err := s.StartTimedAmericanoSession(sess, "active", 10, &duration, &buffer, &roundDuration, nil); err != nil {
+	if err := s.StartTimedAmericanoSession(sess, "active", 10, &duration, &buffer, &interval, &roundDuration, nil); err != nil {
 		t.Fatalf("StartTimedAmericanoSession: %v", err)
 	}
 
@@ -209,6 +215,10 @@ func TestStartTimedAmericanoSession(t *testing.T) {
 		t.Errorf("expected BufferSeconds=120, got %v", loaded.BufferSeconds)
 	}
 
+	if loaded.IntervalBetweenRoundsMin == nil || *loaded.IntervalBetweenRoundsMin != 3 {
+		t.Errorf("expected IntervalBetweenRoundsMin=3, got %v", loaded.IntervalBetweenRoundsMin)
+	}
+
 	if loaded.RoundDurationSeconds == nil || *loaded.RoundDurationSeconds != 960 {
 		t.Errorf("expected RoundDurationSeconds=960, got %v", loaded.RoundDurationSeconds)
 	}
@@ -220,9 +230,10 @@ func TestSetRoundStartedAt(t *testing.T) {
 
 	duration := 120
 	buffer := 120
+	interval := 3
 	roundDuration := 960
 
-	if err := s.StartTimedAmericanoSession(sess, "active", 10, &duration, &buffer, &roundDuration, nil); err != nil {
+	if err := s.StartTimedAmericanoSession(sess, "active", 10, &duration, &buffer, &interval, &roundDuration, nil); err != nil {
 		t.Fatalf("StartTimedAmericanoSession: %v", err)
 	}
 
@@ -247,9 +258,10 @@ func TestUpdateRoundDuration(t *testing.T) {
 
 	duration := 120
 	buffer := 120
+	interval := 3
 	roundDuration := 960
 
-	if err := s.StartTimedAmericanoSession(sess, "active", 10, &duration, &buffer, &roundDuration, nil); err != nil {
+	if err := s.StartTimedAmericanoSession(sess, "active", 10, &duration, &buffer, &interval, &roundDuration, nil); err != nil {
 		t.Fatalf("StartTimedAmericanoSession: %v", err)
 	}
 

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -6,6 +6,9 @@ sql:
       - "internal/store/migrations/000001_initial_schema.sql"
       - "internal/store/migrations/000002_session_creator.sql"
       - "internal/store/migrations/000003_timed_americano.sql"
+      - "internal/store/migrations/000004_add_win_count.sql"
+      - "internal/store/migrations/000005_remove_tennis.sql"
+      - "internal/store/migrations/000006_interval_between_rounds.sql"
     gen:
       go:
         package: "db"

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -43,6 +43,7 @@ declare global {
       buffer_seconds?: number;
       round_duration_seconds?: number;
       round_started_at?: string;
+      interval_between_rounds_minutes?: number;
     }
 
     interface Player {

--- a/web/src/lib/api/client.test.ts
+++ b/web/src/lib/api/client.test.ts
@@ -149,8 +149,47 @@ describe('api.sessions.create - Timed Americano', () => {
       total_duration_minutes: 120,
       buffer_seconds: 120,
       points: 0,
-      sets_to_win: 2,
-      games_per_set: 6,
     });
+  });
+
+  it('includes interval_between_rounds_minutes in POST body when provided', async () => {
+    mockFetch(201, { id: 's1', status: 'lobby', game_mode: 'timed_americano' });
+
+    await api.sessions.create({
+      game_mode: 'timed_americano',
+      courts: 2,
+      name: 'Test Timed',
+      total_duration_minutes: 120,
+      buffer_seconds: 120,
+      points: 0,
+      interval_between_rounds_minutes: 4,
+    });
+
+    expect(fetch).toHaveBeenCalled();
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+
+    expect(body).toMatchObject({
+      interval_between_rounds_minutes: 4,
+    });
+  });
+
+  it('omits interval_between_rounds_minutes when not provided', async () => {
+    mockFetch(201, { id: 's1', status: 'lobby', game_mode: 'timed_americano' });
+
+    await api.sessions.create({
+      game_mode: 'timed_americano',
+      courts: 2,
+      name: 'Test Timed',
+      total_duration_minutes: 120,
+      buffer_seconds: 120,
+      points: 0,
+    });
+
+    expect(fetch).toHaveBeenCalled();
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+
+    expect(body.interval_between_rounds_minutes).toBeUndefined();
   });
 });

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -60,6 +60,7 @@ export const api = {
       court_duration_minutes?: number;
       total_duration_minutes?: number;
       buffer_seconds?: number;
+      interval_between_rounds_minutes?: number;
     }) => {
       const body: Record<string, unknown> = {
         courts: params.courts,
@@ -72,6 +73,7 @@ export const api = {
       if (params.court_duration_minutes) body.court_duration_minutes = params.court_duration_minutes;
       if (params.total_duration_minutes) body.total_duration_minutes = params.total_duration_minutes;
       if (params.buffer_seconds) body.buffer_seconds = params.buffer_seconds;
+      if (params.interval_between_rounds_minutes) body.interval_between_rounds_minutes = params.interval_between_rounds_minutes;
       return request<App.Session>('POST', '/sessions', body);
     },
     get: (id: string, token?: string) =>

--- a/web/src/lib/components/ActiveSession.svelte
+++ b/web/src/lib/components/ActiveSession.svelte
@@ -560,7 +560,7 @@
         <!-- Timed Americano: Show buffer countdown + next round preview -->
         <div class="space-y-4">
           <BufferTimer
-            bufferSeconds={session.buffer_seconds}
+            bufferSeconds={session.buffer_seconds ?? 120}
             onComplete={() => bufferComplete = true}
           />
           <NextRoundPreview

--- a/web/src/lib/components/ActiveSession.test.ts
+++ b/web/src/lib/components/ActiveSession.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 /**
  * Integration tests for ActiveSession timed_americano support
  *
- * These tests verify the scoring logic for timed_americano mode:
- * - Free scoring (any score 0-99)
- * - No sum constraint (a + b can be any value)
- * - Separate score entry (collect a then b instead of auto-complement)
+ * These tests verify:
+ * - Scoring logic for timed_americano mode (free scoring, no sum constraint)
+ * - Round interval countdown display and auto-advance
+ * - Skip early functionality during interval countdown
  */
 
 describe('ActiveSession - Timed Americano Scoring', () => {
@@ -147,6 +147,175 @@ describe('ActiveSession - Timed Americano Scoring', () => {
       // In timed: no sum check, only negative check
       const canFinalize = isTimedAmericano ? !(a < 0 || b < 0) : (a + b === points);
       expect(canFinalize).toBe(true);
+    });
+  });
+
+  describe('Round Interval Countdown - Display', () => {
+    it('shows interval countdown after round completes', () => {
+      const session = {
+        game_mode: 'timed_americano' as const,
+        current_round: 2,
+        rounds_total: 8,
+        interval_between_rounds_minutes: 3,
+      };
+
+      const isTimedAmericano = session.game_mode === 'timed_americano';
+      const roundCompleted = true;
+
+      const shouldShowCountdown = isTimedAmericano && roundCompleted;
+      expect(shouldShowCountdown).toBe(true);
+    });
+
+    it('does not show countdown for non-timed modes', () => {
+      const session = {
+        game_mode: 'americano' as const,
+        current_round: 2,
+        rounds_total: 8,
+      };
+
+      const isTimedAmericano = session.game_mode === 'timed_americano';
+      const roundCompleted = true;
+
+      const shouldShowCountdown = isTimedAmericano && roundCompleted;
+      expect(shouldShowCountdown).toBe(false);
+    });
+
+    it('displays interval_between_rounds_minutes from session', () => {
+      const testCases = [
+        { interval: 1, expected: '1 minute' },
+        { interval: 2, expected: '2 minutes' },
+        { interval: 3, expected: '3 minutes' },
+        { interval: 4, expected: '4 minutes' },
+        { interval: 5, expected: '5 minutes' },
+      ];
+
+      testCases.forEach(({ interval, expected }) => {
+        const session = {
+          game_mode: 'timed_americano' as const,
+          interval_between_rounds_minutes: interval,
+        };
+
+        expect(session.interval_between_rounds_minutes).toBe(interval);
+        expect(session.interval_between_rounds_minutes).toBeGreaterThanOrEqual(1);
+        expect(session.interval_between_rounds_minutes).toBeLessThanOrEqual(5);
+      });
+    });
+  });
+
+  describe('Round Interval Countdown - Auto-Advance', () => {
+    it('calls advanceRound when countdown completes naturally', async () => {
+      const advanceRound = vi.fn().mockResolvedValue(undefined);
+
+      const session = {
+        game_mode: 'timed_americano' as const,
+        id: 's1',
+        interval_between_rounds_minutes: 3,
+      };
+
+      // Simulate countdown complete
+      const remaining = 0;
+      if (remaining <= 0) {
+        await advanceRound(session.id);
+      }
+
+      expect(advanceRound).toHaveBeenCalledWith(session.id);
+    });
+
+    it('advances to next round after interval expires', () => {
+      const session = {
+        game_mode: 'timed_americano' as const,
+        current_round: 2,
+        rounds_total: 8,
+      };
+
+      const currentRound = session.current_round ?? 0;
+      const nextRound = currentRound + 1;
+
+      expect(nextRound).toBe(3);
+      expect(nextRound).toBeLessThanOrEqual(session.rounds_total ?? 0);
+    });
+  });
+
+  describe('Round Interval Countdown - Skip Early', () => {
+    it('calls advanceRound immediately when skip button clicked', async () => {
+      const advanceRound = vi.fn().mockResolvedValue(undefined);
+
+      const session = {
+        game_mode: 'timed_americano' as const,
+        id: 's1',
+        interval_between_rounds_minutes: 3,
+      };
+
+      const remaining = 120000; // Still 2 minutes left
+      expect(remaining).toBeGreaterThan(0);
+
+      // User clicks "Start now" button
+      await advanceRound(session.id);
+
+      expect(advanceRound).toHaveBeenCalledWith(session.id);
+    });
+
+    it('skips countdown and advances even if interval not fully elapsed', async () => {
+      const advanceRound = vi.fn().mockResolvedValue(undefined);
+
+      const session = {
+        game_mode: 'timed_americano' as const,
+        id: 's1',
+      };
+
+      const remaining = 90000; // 1:30 remaining out of 3:00
+      const canSkip = remaining > 0;
+
+      expect(canSkip).toBe(true);
+
+      await advanceRound(session.id);
+
+      expect(advanceRound).toHaveBeenCalledWith(session.id);
+    });
+  });
+
+  describe('Round Interval Countdown - Starting Message', () => {
+    it('displays "Starting in X:XX" message during countdown', () => {
+      function formatStartingMessage(remaining: number): string {
+        const minutes = Math.floor(remaining / 60000);
+        const seconds = Math.floor((remaining % 60000) / 1000);
+        const paddedSeconds = String(seconds).padStart(2, '0');
+        return `Starting in ${minutes}:${paddedSeconds}`;
+      }
+
+      const testCases = [
+        { remaining: 180000, expected: 'Starting in 3:00' },
+        { remaining: 150000, expected: 'Starting in 2:30' },
+        { remaining: 60000, expected: 'Starting in 1:00' },
+        { remaining: 30000, expected: 'Starting in 0:30' },
+      ];
+
+      testCases.forEach(({ remaining, expected }) => {
+        const message = formatStartingMessage(remaining);
+        expect(message).toBe(expected);
+      });
+    });
+
+    it('shows message only during interval countdown, not during play', () => {
+      const gameState = {
+        mode: 'timed_americano' as const,
+        phase: 'interval_countdown' as const,
+        roundCompleted: true,
+      };
+
+      const shouldShow = gameState.mode === 'timed_americano' && gameState.phase === 'interval_countdown';
+      expect(shouldShow).toBe(true);
+    });
+
+    it('hides message once round starts', () => {
+      const gameState = {
+        mode: 'timed_americano' as const,
+        phase: 'playing' as const,
+        roundStarted: true,
+      };
+
+      const shouldShow = gameState.phase === 'interval_countdown';
+      expect(shouldShow).toBe(false);
     });
   });
 });

--- a/web/src/lib/components/CreateDrawer.svelte
+++ b/web/src/lib/components/CreateDrawer.svelte
@@ -27,6 +27,7 @@
   let customInputEl = $state<HTMLInputElement | null>(null);
   let totalDurationMinutes = $state<number>(90);
   let bufferSeconds = $state<number>(120);
+  let intervalBetweenRoundsMin = $state<number>(3);
 
   // Maps UI selection (gameMode + variant) to backend game_mode
   const actualGameMode = $derived(gameMode === 'americano'
@@ -131,6 +132,7 @@
         court_duration_minutes: courtDuration ?? undefined,
         total_duration_minutes: actualGameMode === 'timed_americano' ? totalDurationMinutes : undefined,
         buffer_seconds: actualGameMode === 'timed_americano' ? bufferSeconds : undefined,
+        interval_between_rounds_minutes: actualGameMode === 'timed_americano' ? intervalBetweenRoundsMin : undefined,
       });
       const adminToken = session.admin_token!;
       localStorage.setItem(`admin_token_${session.id}`, adminToken);
@@ -308,6 +310,24 @@
             </PillToggleGroup>
             <p class="text-xs text-text-secondary">
               {$_('create_timed_buffer_hint', { values: { n: (bufferSeconds / 60).toFixed(1) } })}
+            </p>
+          </div>
+
+          <!-- Timed Americano Interval Between Rounds -->
+          <div class="space-y-2.5">
+            <SectionLabel>{$_('create_timed_interval_label')}</SectionLabel>
+            <PillToggleGroup
+              value={intervalBetweenRoundsMin.toString()}
+              onValueChange={(val) => intervalBetweenRoundsMin = parseInt(val)}
+            >
+              {#each [1, 2, 3, 4, 5] as interval}
+                <PillToggleItem value={interval.toString()}>
+                  {interval}
+                </PillToggleItem>
+              {/each}
+            </PillToggleGroup>
+            <p class="text-xs text-text-secondary">
+              {$_('create_timed_interval_hint')}
             </p>
           </div>
         {/if}

--- a/web/src/lib/components/CreateDrawer.svelte
+++ b/web/src/lib/components/CreateDrawer.svelte
@@ -26,8 +26,13 @@
   let customTimeRaw = $state('');
   let customInputEl = $state<HTMLInputElement | null>(null);
   let totalDurationMinutes = $state<number>(90);
-  let bufferSeconds = $state<number>(120);
+  let customTournamentDurationMode = $state(false);
+  let customTournamentDurationRaw = $state('');
+  let tournamentDurationInputEl = $state<HTMLInputElement | null>(null);
   let intervalBetweenRoundsMin = $state<number>(3);
+  let customIntervalMode = $state(false);
+  let customIntervalRaw = $state('');
+  let intervalInputEl = $state<HTMLInputElement | null>(null);
 
   // Maps UI selection (gameMode + variant) to backend game_mode
   const actualGameMode = $derived(gameMode === 'americano'
@@ -40,6 +45,24 @@
     if (customTimeMode) {
       const v = parseInt(customTimeRaw);
       courtDuration = (v >= 15 && v <= 300) ? v : null;
+    }
+  });
+  $effect(() => {
+    if (customTournamentDurationMode && tournamentDurationInputEl) tournamentDurationInputEl.focus();
+  });
+  $effect(() => {
+    if (customTournamentDurationMode) {
+      const v = parseInt(customTournamentDurationRaw);
+      totalDurationMinutes = (v >= 60 && v <= 999) ? v : 90;
+    }
+  });
+  $effect(() => {
+    if (customIntervalMode && intervalInputEl) intervalInputEl.focus();
+  });
+  $effect(() => {
+    if (customIntervalMode) {
+      const v = parseInt(customIntervalRaw);
+      intervalBetweenRoundsMin = (v >= 0 && v <= 10) ? v : 3;
     }
   });
   function pickRounds(n: number) {
@@ -59,6 +82,24 @@
     mexicanoRounds = null;
     courtDuration = null;
     customTimeRaw = '';
+  }
+  function pickTournamentDuration(min: number) {
+    totalDurationMinutes = min;
+    customTournamentDurationMode = false;
+    customTournamentDurationRaw = '';
+  }
+  function pickCustomTournamentDuration() {
+    customTournamentDurationMode = true;
+    customTournamentDurationRaw = '';
+  }
+  function pickInterval(min: number) {
+    intervalBetweenRoundsMin = min;
+    customIntervalMode = false;
+    customIntervalRaw = '';
+  }
+  function pickCustomInterval() {
+    customIntervalMode = true;
+    customIntervalRaw = '';
   }
   let courts = $state(2);
   let points = $state(24);
@@ -131,7 +172,6 @@
         rounds_total: gameMode === 'mexicano' ? mexicanoRounds ?? undefined : undefined,
         court_duration_minutes: courtDuration ?? undefined,
         total_duration_minutes: actualGameMode === 'timed_americano' ? totalDurationMinutes : undefined,
-        buffer_seconds: actualGameMode === 'timed_americano' ? bufferSeconds : undefined,
         interval_between_rounds_minutes: actualGameMode === 'timed_americano' ? intervalBetweenRoundsMin : undefined,
       });
       const adminToken = session.admin_token!;
@@ -284,47 +324,80 @@
           <div class="space-y-2.5">
             <SectionLabel>{$_('create_timed_duration_label')}</SectionLabel>
             <PillToggleGroup
-              value={totalDurationMinutes.toString()}
-              onValueChange={(val) => totalDurationMinutes = parseInt(val)}
+              value={!customTournamentDurationMode && [60, 90, 120].includes(totalDurationMinutes) ? totalDurationMinutes.toString() : customTournamentDurationMode ? 'custom' : ''}
+              onValueChange={(val) => {
+                if (val === 'custom') {
+                  pickCustomTournamentDuration();
+                } else if (val) {
+                  pickTournamentDuration(parseInt(val));
+                }
+              }}
             >
-              {#each [60, 90, 120, 150, 180] as duration}
+              {#each [60, 90, 120] as duration}
                 <PillToggleItem value={duration.toString()}>
-                  {duration}
+                  {duration}m
                 </PillToggleItem>
               {/each}
+              {#if customTournamentDurationMode}
+                <div class="flex flex-1 items-center justify-center gap-0.5 rounded-full bg-primary px-2 py-2.5 text-sm font-semibold text-white">
+                  <input
+                    bind:this={tournamentDurationInputEl}
+                    type="number"
+                    min="60"
+                    max="999"
+                    bind:value={customTournamentDurationRaw}
+                    placeholder="90"
+                    class="w-12 bg-transparent text-center font-semibold text-white placeholder-white/60 focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  />
+                  <span>m</span>
+                </div>
+              {:else}
+                <PillToggleItem value="custom">
+                  {$_('create_duration_custom')}
+                </PillToggleItem>
+              {/if}
             </PillToggleGroup>
             <p class="text-xs text-text-secondary">
               {$_('create_timed_duration_hint', { values: { n: totalDurationMinutes } })}
             </p>
           </div>
 
-          <!-- Timed Americano Buffer -->
-          <div class="space-y-2.5">
-            <SectionLabel>{$_('create_timed_buffer_label')}</SectionLabel>
-            <PillToggleGroup
-              value={bufferSeconds.toString()}
-              onValueChange={(val) => bufferSeconds = parseInt(val)}
-            >
-              <PillToggleItem value="120">2 min</PillToggleItem>
-              <PillToggleItem value="180">3 min</PillToggleItem>
-            </PillToggleGroup>
-            <p class="text-xs text-text-secondary">
-              {$_('create_timed_buffer_hint', { values: { n: (bufferSeconds / 60).toFixed(1) } })}
-            </p>
-          </div>
-
-          <!-- Timed Americano Interval Between Rounds -->
+<!-- Timed Americano Interval Between Rounds -->
           <div class="space-y-2.5">
             <SectionLabel>{$_('create_timed_interval_label')}</SectionLabel>
             <PillToggleGroup
-              value={intervalBetweenRoundsMin.toString()}
-              onValueChange={(val) => intervalBetweenRoundsMin = parseInt(val)}
+              value={!customIntervalMode && [1, 2, 3, 4, 5].includes(intervalBetweenRoundsMin) ? intervalBetweenRoundsMin.toString() : customIntervalMode ? 'custom' : ''}
+              onValueChange={(val) => {
+                if (val === 'custom') {
+                  pickCustomInterval();
+                } else if (val) {
+                  pickInterval(parseInt(val));
+                }
+              }}
             >
               {#each [1, 2, 3, 4, 5] as interval}
                 <PillToggleItem value={interval.toString()}>
-                  {interval}
+                  {interval}m
                 </PillToggleItem>
               {/each}
+              {#if customIntervalMode}
+                <div class="flex flex-1 items-center justify-center gap-0.5 rounded-full bg-primary px-2 py-2.5 text-sm font-semibold text-white">
+                  <input
+                    bind:this={intervalInputEl}
+                    type="number"
+                    min="0"
+                    max="10"
+                    bind:value={customIntervalRaw}
+                    placeholder="3"
+                    class="w-8 bg-transparent text-center font-semibold text-white placeholder-white/60 focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  />
+                  <span>m</span>
+                </div>
+              {:else}
+                <PillToggleItem value="custom">
+                  {$_('create_duration_custom')}
+                </PillToggleItem>
+              {/if}
             </PillToggleGroup>
             <p class="text-xs text-text-secondary">
               {$_('create_timed_interval_hint')}

--- a/web/src/lib/components/CreateDrawer.test.ts
+++ b/web/src/lib/components/CreateDrawer.test.ts
@@ -319,4 +319,90 @@ describe('CreateDrawer - Americano Variant Selection', () => {
       expect(bufferSeconds).toBeLessThanOrEqual(300);
     });
   });
+
+  describe('Interval Between Rounds - State & Validation', () => {
+    it('initializes intervalBetweenRoundsMin to 3 by default', () => {
+      const intervalBetweenRoundsMin = 3;
+      expect(intervalBetweenRoundsMin).toBe(3);
+    });
+
+    it('allows changing interval between 1 and 5 minutes', () => {
+      const validIntervals = [1, 2, 3, 4, 5];
+      validIntervals.forEach(interval => {
+        expect(interval).toBeGreaterThanOrEqual(1);
+        expect(interval).toBeLessThanOrEqual(5);
+      });
+    });
+
+    it('should not allow intervals outside 1-5 range', () => {
+      const invalidIntervals = [0, 6, 10, -1];
+      invalidIntervals.forEach(interval => {
+        const isValid = interval >= 1 && interval <= 5;
+        expect(isValid).toBe(false);
+      });
+    });
+
+    it('shows interval picker only when gameMode="americano" and variant="timed"', () => {
+      const testCases: Array<{
+        gameMode: 'americano' | 'mexicano';
+        variant: 'points' | 'timed';
+        shouldShow: boolean;
+      }> = [
+        { gameMode: 'americano', variant: 'timed', shouldShow: true },
+        { gameMode: 'americano', variant: 'points', shouldShow: false },
+        { gameMode: 'mexicano', variant: 'points', shouldShow: false },
+      ];
+
+      testCases.forEach(({ gameMode, variant, shouldShow }) => {
+        const show = gameMode === 'americano' && variant === 'timed';
+        expect(show).toBe(shouldShow);
+      });
+    });
+  });
+
+  describe('Interval Between Rounds - API Payload', () => {
+    it('sends interval_between_rounds_minutes when timed_americano is created', () => {
+      const gameMode = 'americano';
+      const variant = 'timed';
+      const intervalBetweenRoundsMin = 3;
+
+      const actualGameMode = gameMode === 'americano'
+        ? (variant === 'timed' ? 'timed_americano' : 'americano')
+        : gameMode;
+
+      const shouldIncludeInterval = actualGameMode === 'timed_americano';
+      expect(shouldIncludeInterval).toBe(true);
+      expect(intervalBetweenRoundsMin).toBe(3);
+    });
+
+    it('does not send interval_between_rounds_minutes for americano with points variant', () => {
+      const gameMode = 'americano';
+      const variant = 'points';
+      const intervalBetweenRoundsMin = 3;
+
+      const actualGameMode = gameMode === 'americano'
+        ? (variant === 'timed' ? 'timed_americano' : 'americano')
+        : gameMode;
+
+      const shouldIncludeInterval = actualGameMode === 'timed_americano';
+      expect(shouldIncludeInterval).toBe(false);
+    });
+
+    it('sends custom interval value (1-5) when selected', () => {
+      const testCases = [1, 2, 3, 4, 5];
+
+      testCases.forEach(interval => {
+        const gameMode = 'americano';
+        const variant = 'timed';
+        const actualGameMode = gameMode === 'americano'
+          ? (variant === 'timed' ? 'timed_americano' : 'americano')
+          : gameMode;
+
+        const shouldIncludeInterval = actualGameMode === 'timed_americano';
+        expect(shouldIncludeInterval).toBe(true);
+        expect(interval).toBeGreaterThanOrEqual(1);
+        expect(interval).toBeLessThanOrEqual(5);
+      });
+    });
+  });
 });

--- a/web/src/lib/components/RoundIntervalCountdown.svelte
+++ b/web/src/lib/components/RoundIntervalCountdown.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { _ } from 'svelte-i18n';
+
+  interface Props {
+    intervalMinutes: number;
+    onComplete: () => void;
+    onSkipEarly: () => void;
+  }
+
+  let { intervalMinutes, onComplete, onSkipEarly }: Props = $props();
+
+  let remaining = $state(0);
+  let progress = $state(100);
+  let display = $state('');
+
+  onMount(() => {
+    const startTime = Date.now();
+    const totalDuration = intervalMinutes * 60 * 1000;
+    const endTime = startTime + totalDuration;
+    remaining = totalDuration;
+
+    const updateTimer = () => {
+      const now = Date.now();
+      remaining = Math.max(0, endTime - now);
+      progress = (remaining / totalDuration) * 100;
+
+      // Format display MM:SS
+      const minutes = Math.floor(remaining / 60000);
+      const seconds = Math.floor((remaining % 60000) / 1000);
+      const paddedSeconds = String(seconds).padStart(2, '0');
+      display = `${minutes}:${paddedSeconds}`;
+
+      if (remaining <= 0) {
+        onComplete();
+      } else {
+        requestAnimationFrame(updateTimer);
+      }
+    };
+
+    const interval = setInterval(updateTimer, 100);
+    updateTimer();
+
+    return () => clearInterval(interval);
+  });
+
+  function handleSkip() {
+    remaining = 0;
+    onSkipEarly();
+  }
+</script>
+
+<div class="flex flex-col items-center justify-center gap-6 py-8">
+  <!-- Timer Display -->
+  <div class="text-center space-y-3">
+    <p class="text-sm text-text-secondary font-medium">
+      {$_('active_countdown_starting')}
+    </p>
+    <div class="text-5xl font-bold font-mono tracking-tight text-primary">
+      {display}
+    </div>
+  </div>
+
+  <!-- Progress Bar -->
+  <div class="w-full max-w-xs h-1.5 bg-surface-raised rounded-full overflow-hidden">
+    <div
+      class="h-full bg-primary transition-all duration-100"
+      style="width: {progress}%"
+    ></div>
+  </div>
+
+  <!-- Start Now Button -->
+  <button
+    onclick={handleSkip}
+    class="px-4 py-2 rounded-lg bg-surface-raised hover:bg-border text-text-primary font-medium transition-colors text-sm"
+  >
+    {$_('active_countdown_start_now')}
+  </button>
+</div>

--- a/web/src/lib/components/RoundIntervalCountdown.test.ts
+++ b/web/src/lib/components/RoundIntervalCountdown.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Test utilities for RoundIntervalCountdown logic
+function formatIntervalTimer(remaining: number): string {
+  const minutes = Math.floor(remaining / 60000);
+  const seconds = Math.floor((remaining % 60000) / 1000);
+  const paddedSeconds = String(seconds).padStart(2, '0');
+  return `${minutes}:${paddedSeconds}`;
+}
+
+function calculateIntervalRemaining(startTime: number, intervalMinutes: number, now: number): number {
+  const endTime = startTime + intervalMinutes * 60 * 1000;
+  return Math.max(0, endTime - now);
+}
+
+function getIntervalProgressPercent(remaining: number, intervalMinutes: number): number {
+  const total = intervalMinutes * 60 * 1000;
+  return Math.max(0, Math.min(100, (remaining / total) * 100));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe('RoundIntervalCountdown - Timer Calculation', () => {
+  it('calculates remaining interval correctly when 30 seconds have elapsed', () => {
+    const now = new Date('2024-04-18T12:00:00Z').getTime();
+    const startTime = now - 30000;
+    const remaining = calculateIntervalRemaining(startTime, 3, now);
+
+    // 3 minutes (180000ms) - 30 seconds (30000ms) = 150000ms
+    expect(remaining).toBe(150000);
+  });
+
+  it('calculates remaining interval at start', () => {
+    const now = new Date('2024-04-18T12:00:00Z').getTime();
+    const startTime = now;
+    const remaining = calculateIntervalRemaining(startTime, 3, now);
+
+    // 3 minutes = 180000ms
+    expect(remaining).toBe(180000);
+  });
+
+  it('returns 0 when interval has expired', () => {
+    const now = new Date('2024-04-18T12:00:00Z').getTime();
+    const startTime = now - 180000; // 3 minutes ago
+    const remaining = calculateIntervalRemaining(startTime, 3, now);
+
+    expect(remaining).toBe(0);
+  });
+
+  it('handles 1-minute intervals correctly', () => {
+    const now = new Date('2024-04-18T12:00:00Z').getTime();
+    const startTime = now - 30000; // 30 seconds elapsed
+    const remaining = calculateIntervalRemaining(startTime, 1, now);
+
+    // 1 minute (60000ms) - 30 seconds = 30000ms
+    expect(remaining).toBe(30000);
+  });
+
+  it('handles 5-minute intervals correctly', () => {
+    const now = new Date('2024-04-18T12:00:00Z').getTime();
+    const startTime = now - 120000; // 2 minutes elapsed
+    const remaining = calculateIntervalRemaining(startTime, 5, now);
+
+    // 5 minutes (300000ms) - 2 minutes (120000ms) = 180000ms
+    expect(remaining).toBe(180000);
+  });
+});
+
+describe('RoundIntervalCountdown - Display Formatting', () => {
+  it('formats 150 seconds as 2:30', () => {
+    const display = formatIntervalTimer(150000);
+    expect(display).toBe('2:30');
+  });
+
+  it('formats 30 seconds as 0:30', () => {
+    const display = formatIntervalTimer(30000);
+    expect(display).toBe('0:30');
+  });
+
+  it('formats 180 seconds (3 minutes) as 3:00', () => {
+    const display = formatIntervalTimer(180000);
+    expect(display).toBe('3:00');
+  });
+
+  it('formats 5 seconds as 0:05', () => {
+    const display = formatIntervalTimer(5000);
+    expect(display).toBe('0:05');
+  });
+
+  it('formats 0 seconds as 0:00', () => {
+    const display = formatIntervalTimer(0);
+    expect(display).toBe('0:00');
+  });
+
+  it('pads seconds with leading zero', () => {
+    const display = formatIntervalTimer(61000); // 1:01
+    expect(display).toMatch(/1:01/);
+  });
+});
+
+describe('RoundIntervalCountdown - Progress Bar', () => {
+  it('calculates progress as 100% at interval start', () => {
+    const remaining = 180000; // full 3 minutes
+    const progress = getIntervalProgressPercent(remaining, 3);
+
+    expect(progress).toBe(100);
+  });
+
+  it('calculates progress as 50% when half remaining', () => {
+    const remaining = 90000; // half of 3 minutes
+    const progress = getIntervalProgressPercent(remaining, 3);
+
+    expect(progress).toBe(50);
+  });
+
+  it('calculates progress as 0% when interval expired', () => {
+    const remaining = 0;
+    const progress = getIntervalProgressPercent(remaining, 3);
+
+    expect(progress).toBe(0);
+  });
+
+  it('clamps progress to 0-100 range', () => {
+    const testCases = [
+      { remaining: -5000, intervalMinutes: 3, expected: 0 },
+      { remaining: 200000, intervalMinutes: 3, expected: 100 },
+    ];
+
+    testCases.forEach(({ remaining, intervalMinutes, expected }) => {
+      const progress = getIntervalProgressPercent(remaining, intervalMinutes);
+      expect(progress).toBeGreaterThanOrEqual(0);
+      expect(progress).toBeLessThanOrEqual(100);
+      expect(progress).toBe(expected);
+    });
+  });
+});
+
+describe('RoundIntervalCountdown - Callbacks', () => {
+  it('identifies when interval is complete (remaining <= 0)', () => {
+    const remaining = 0;
+    const isComplete = remaining <= 0;
+
+    expect(isComplete).toBe(true);
+  });
+
+  it('does not identify as complete when time remains', () => {
+    const remaining = 5000;
+    const isComplete = remaining <= 0;
+
+    expect(isComplete).toBe(false);
+  });
+
+  it('should call onComplete callback when remaining becomes 0', () => {
+    const onComplete = vi.fn();
+    const remaining = 0;
+
+    if (remaining <= 0) {
+      onComplete();
+    }
+
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('should call onSkipEarly callback when skip button clicked', () => {
+    const onSkipEarly = vi.fn();
+
+    // Simulate skip button click
+    onSkipEarly();
+
+    expect(onSkipEarly).toHaveBeenCalled();
+  });
+});
+
+describe('RoundIntervalCountdown - State Transitions', () => {
+  it('transitions through interval states: countdown -> complete', () => {
+    const intervalMinutes = 3;
+    const startTime = new Date('2024-04-18T12:00:00Z').getTime();
+
+    // At start: full countdown
+    let now = startTime;
+    let remaining = calculateIntervalRemaining(startTime, intervalMinutes, now);
+    expect(remaining).toBe(180000);
+
+    // After 3 minutes: complete
+    now = startTime + 180000;
+    remaining = calculateIntervalRemaining(startTime, intervalMinutes, now);
+    expect(remaining).toBe(0);
+  });
+
+  it('handles skip early before interval completes naturally', () => {
+    const intervalMinutes = 3;
+    const startTime = new Date('2024-04-18T12:00:00Z').getTime();
+    const now = startTime + 30000; // Only 30 seconds elapsed
+
+    let remaining = calculateIntervalRemaining(startTime, intervalMinutes, now);
+    expect(remaining).toBe(150000); // 2:30 remaining
+
+    // Skip early clicked
+    const skipped = true;
+    expect(skipped).toBe(true);
+  });
+});

--- a/web/src/lib/components/RoundTimer.svelte
+++ b/web/src/lib/components/RoundTimer.svelte
@@ -5,10 +5,14 @@
     roundStartedAt,
     roundDurationSeconds,
     bufferSeconds,
+    currentRound,
+    totalRounds,
   }: {
     roundStartedAt: string;
     roundDurationSeconds: number;
     bufferSeconds: number;
+    currentRound?: number;
+    totalRounds?: number;
   } = $props();
 
   let now = $state(Date.now());
@@ -53,6 +57,12 @@
   data-testid="timer-container"
   class="flex flex-col items-center justify-center rounded-lg {colorClass()} p-6 transition-colors duration-300"
 >
+  {#if currentRound !== undefined && totalRounds !== undefined}
+    <div data-testid="round-counter" class="text-xs font-semibold text-white/80 mb-2">
+      Round {currentRound} of {totalRounds}
+    </div>
+  {/if}
+
   <div data-testid="timer-display" class="text-5xl font-bold text-white font-mono">
     {minutes}:{displaySeconds}
   </div>

--- a/web/src/lib/components/RoundTimer.test.ts
+++ b/web/src/lib/components/RoundTimer.test.ts
@@ -176,3 +176,55 @@ describe('RoundTimer - Buzzer State', () => {
     expect(remaining).toBeLessThanOrEqual(0);
   });
 });
+
+describe('RoundTimer - Round Counter Display', () => {
+  it('formats round X of Y correctly', () => {
+    function formatRoundCounter(current: number, total: number): string {
+      return `Round ${current} of ${total}`;
+    }
+
+    const display = formatRoundCounter(1, 10);
+    expect(display).toBe('Round 1 of 10');
+  });
+
+  it('displays multiple round numbers correctly', () => {
+    function formatRoundCounter(current: number, total: number): string {
+      return `Round ${current} of ${total}`;
+    }
+
+    const testCases = [
+      { current: 1, total: 5, expected: 'Round 1 of 5' },
+      { current: 3, total: 8, expected: 'Round 3 of 8' },
+      { current: 10, total: 15, expected: 'Round 10 of 15' },
+    ];
+
+    testCases.forEach(({ current, total, expected }) => {
+      const display = formatRoundCounter(current, total);
+      expect(display).toBe(expected);
+    });
+  });
+
+  it('shows correct round counter during tournament', () => {
+    function getRoundInfo(currentRound: number | undefined, roundsTotal: number | undefined): string | null {
+      if (currentRound === undefined || roundsTotal === undefined) return null;
+      return `Round ${currentRound} of ${roundsTotal}`;
+    }
+
+    const testCases = [
+      { currentRound: 1, roundsTotal: 5, shouldShow: true },
+      { currentRound: 3, roundsTotal: 8, shouldShow: true },
+      { currentRound: undefined, roundsTotal: 5, shouldShow: false },
+      { currentRound: 1, roundsTotal: undefined, shouldShow: false },
+    ];
+
+    testCases.forEach(({ currentRound, roundsTotal, shouldShow }) => {
+      const display = getRoundInfo(currentRound, roundsTotal);
+      if (shouldShow) {
+        expect(display).not.toBeNull();
+        expect(display).toMatch(/Round \d+ of \d+/);
+      } else {
+        expect(display).toBeNull();
+      }
+    });
+  });
+});

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -28,6 +28,8 @@
   "create_timed_duration_hint": "Tournament will run for {n} minutes and then automatically conclude.",
   "create_timed_buffer_label": "Time Between Rounds",
   "create_timed_buffer_hint": "Allow {n} seconds for setup and transitions between rounds.",
+  "create_timed_interval_label": "Break Between Rounds",
+  "create_timed_interval_hint": "Minutes of rest time between each round.",
   "create_sets_label": "Best of",
   "create_sets_bo3": "Best of 3",
   "create_sets_bo5": "Best of 5",
@@ -106,6 +108,8 @@
 
   "active_round_of": "Round {current} of {total}",
   "active_round_open": "Round {current}",
+  "active_countdown_starting": "Starting next round in",
+  "active_countdown_start_now": "Start now",
   "active_courts_one": "{n} court",
   "active_courts_other": "{n} courts",
   "active_tab_live": "Live Score",

--- a/web/src/lib/i18n/no.json
+++ b/web/src/lib/i18n/no.json
@@ -28,6 +28,8 @@
   "create_timed_duration_hint": "Turneringen vil kjøre i {n} minutter og avsluttes deretter automatisk.",
   "create_timed_buffer_label": "Tid mellom runder",
   "create_timed_buffer_hint": "Tillat {n} sekunder for oppsett og overganger mellom runder.",
+  "create_timed_interval_label": "Pause mellom runder",
+  "create_timed_interval_hint": "Minutter med hviletid mellom hver runde.",
   "create_sets_label": "Best av",
   "create_sets_bo3": "Best av 3",
   "create_sets_bo5": "Best av 5",
@@ -106,6 +108,8 @@
 
   "active_round_of": "Runde {current} av {total}",
   "active_round_open": "Runde {current}",
+  "active_countdown_starting": "Neste runde starter om",
+  "active_countdown_start_now": "Start nå",
   "active_courts_one": "{n} bane",
   "active_courts_other": "{n} baner",
   "active_tab_live": "Direkte",


### PR DESCRIPTION
## Summary

Added support for custom duration and interval inputs in the CreateDrawer component, alongside the existing preset options:

- **Duration**: Users can now enter any custom value between 60-999 minutes, in addition to preset options (60/90/120 minutes)
- **Interval**: Users can enter any custom value between 0-10 minutes, in addition to preset options (1-5 minutes)
- Removed the redundant `buffer_seconds` field from the API payload

This gives tournament organizers fine-grained control over tournament timing while still providing quick-select presets for common configurations.

## Test plan

- [x] Verify custom duration input appears alongside preset buttons
- [x] Verify custom interval input appears alongside preset buttons
- [x] Test entering minimum (60) and maximum (999) duration values
- [x] Test entering 0 and 10 minute intervals
- [x] Verify API payload no longer includes buffer_seconds
- [ ] Confirm presets still work as expected