### PR TITLE
feat: refactor Americano service and add state validation (closes #60, #63)

### DIFF
--- a/internal/api/rounds.go
+++ b/internal/api/rounds.go
@@ -73,7 +73,7 @@ func (h *Handler) submitScore(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, "server_error")
 		return
 	}
-	if sess.Status != domain.StatusActive {
+	if sess.Status != domain.StatusPlaying {
 		respondError(w, http.StatusConflict, "session_not_active")
 		return
 	}
@@ -182,7 +182,7 @@ func (h *Handler) advanceRound(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusForbidden, "admin_required")
 		return
 	}
-	if sess.Status != domain.StatusActive {
+	if sess.Status != domain.StatusPlaying {
 		respondError(w, http.StatusConflict, "session_not_active")
 		return
 	}

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -225,7 +225,7 @@ func (h *Handler) closeSession(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusForbidden, "admin_required")
 		return
 	}
-	if sess.Status == domain.StatusComplete {
+	if sess.Status == domain.StatusDone {
 		respondError(w, http.StatusConflict, "session_already_ended")
 		return
 	}

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -101,6 +101,17 @@ func (h *Handler) getSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Compute validation errors for the current session state.
+	if sess.Status == domain.StatusLobby {
+		switch sess.GameMode {
+		case "mexicano":
+			sess.ValidationErrors = domain.MexicanoConstraints(sess.Courts, len(activePlayers(sess.Players)))
+		default: // americano
+			sess.ValidationErrors = domain.AmericanoConstraints(sess.Courts, len(activePlayers(sess.Players)))
+		}
+		sess.CanStart = len(sess.ValidationErrors) == 0
+	}
+
 	// Treat the logged-in creator the same as a token-holding admin.
 	u := userFromContext(r)
 	if u != nil && sess.CreatorUserID != "" && u.ID == sess.CreatorUserID {
@@ -134,6 +145,23 @@ func (h *Handler) startSession(w http.ResponseWriter, r *http.Request) {
 
 	active := activePlayers(sess.Players)
 
+	// Validate constraints before starting.
+	var validationErrs []domain.ValidationError
+	switch sess.GameMode {
+	case "mexicano":
+		validationErrs = domain.MexicanoConstraints(sess.Courts, len(active))
+	default: // americano
+		validationErrs = domain.AmericanoConstraints(sess.Courts, len(active))
+	}
+	if len(validationErrs) > 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"validation_errors": validationErrs,
+		}) //nolint:errcheck
+		return
+	}
+
 	// Compute ends_at from court_duration_minutes if set.
 	var endsAt *time.Time
 	if sess.CourtDurationMinutes != nil && *sess.CourtDurationMinutes > 0 {
@@ -143,20 +171,10 @@ func (h *Handler) startSession(w http.ResponseWriter, r *http.Request) {
 
 	switch sess.GameMode {
 	case "mexicano":
-		required := sess.Courts * 4
-		if len(active) != required {
-			respondError(w, http.StatusUnprocessableEntity, "mexicano_player_count")
-			return
-		}
 		if err := h.mexicanoSvc.Start(w, id, sess, active, endsAt); err != nil {
 			return
 		}
 	default: // americano
-		minPlayers := sess.Courts * 4
-		if len(active) < minPlayers {
-			respondError(w, http.StatusUnprocessableEntity, "not_enough_players")
-			return
-		}
 		if err := h.americanoSvc.Start(w, id, sess, active, endsAt); err != nil {
 			return
 		}

--- a/internal/api/sessions_test.go
+++ b/internal/api/sessions_test.go
@@ -125,8 +125,8 @@ func TestStartSession(t *testing.T) {
 		Status string `json:"status"`
 	}
 	decodeBody(t, res, &session)
-	if session.Status != "active" {
-		t.Errorf("expected status 'active' after start, got %q", session.Status)
+	if session.Status != "playing" {
+		t.Errorf("expected status 'playing' after start, got %q", session.Status)
 	}
 }
 
@@ -137,8 +137,8 @@ func TestStartSession_NotEnoughPlayers(t *testing.T) {
 	mustJoinSession(t, srv, sessID, "Alice", adminToken)
 
 	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
-	if res.StatusCode != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d", res.StatusCode)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.StatusCode)
 	}
 	res.Body.Close()
 }
@@ -174,8 +174,8 @@ func TestCloseSession(t *testing.T) {
 		Status string `json:"status"`
 	}
 	decodeBody(t, res2, &session)
-	if session.Status != "complete" {
-		t.Errorf("expected status 'complete' after close, got %q", session.Status)
+	if session.Status != "done" {
+		t.Errorf("expected status 'done' after close, got %q", session.Status)
 	}
 }
 

--- a/internal/domain/constraints.go
+++ b/internal/domain/constraints.go
@@ -1,0 +1,63 @@
+package domain
+
+// ValidationError represents a constraint violation with a structured error code and parameters.
+type ValidationError struct {
+	Code   string                 `json:"code"`
+	Params map[string]interface{} `json:"params"`
+}
+
+// AmericanoConstraints validates an Americano session configuration.
+// Returns a list of validation errors; empty list means all constraints are satisfied.
+func AmericanoConstraints(courts, playerCount int) []ValidationError {
+	var errs []ValidationError
+
+	// Courts validation: 1-20
+	if courts < 1 || courts > 20 {
+		errs = append(errs, ValidationError{
+			Code:   "americano_invalid_courts",
+			Params: map[string]interface{}{"courts": courts, "min": 1, "max": 20},
+		})
+	}
+
+	// Players validation: >= courts * 4
+	minPlayers := courts * 4
+	if playerCount < minPlayers {
+		errs = append(errs, ValidationError{
+			Code: "americano_insufficient_players",
+			Params: map[string]interface{}{
+				"required": minPlayers,
+				"current":  playerCount,
+			},
+		})
+	}
+
+	return errs
+}
+
+// MexicanoConstraints validates a Mexicano session configuration.
+// Returns a list of validation errors; empty list means all constraints are satisfied.
+func MexicanoConstraints(courts, playerCount int) []ValidationError {
+	var errs []ValidationError
+
+	// Courts validation: 1-20
+	if courts < 1 || courts > 20 {
+		errs = append(errs, ValidationError{
+			Code:   "mexicano_invalid_courts",
+			Params: map[string]interface{}{"courts": courts, "min": 1, "max": 20},
+		})
+	}
+
+	// Players validation: exactly courts * 4 (no bench)
+	requiredPlayers := courts * 4
+	if playerCount != requiredPlayers {
+		errs = append(errs, ValidationError{
+			Code: "mexicano_player_count_mismatch",
+			Params: map[string]interface{}{
+				"required": requiredPlayers,
+				"current":  playerCount,
+			},
+		})
+	}
+
+	return errs
+}

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -77,8 +77,8 @@ type SessionStatus string
 
 const (
 	StatusLobby    SessionStatus = "lobby"
-	StatusActive   SessionStatus = "active"
-	StatusComplete SessionStatus = "complete"
+	StatusPlaying  SessionStatus = "playing"
+	StatusDone     SessionStatus = "done"
 )
 
 type Session struct {

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -97,9 +97,11 @@ type Session struct {
 	ScheduledAt              *time.Time    `json:"scheduled_at,omitempty"`
 	CourtDurationMinutes     *int          `json:"court_duration_minutes,omitempty"`
 	EndsAt                   *time.Time    `json:"ends_at,omitempty"`
-	Players                  []Player      `json:"players"`
-	CreatedAt                time.Time     `json:"created_at"`
-	UpdatedAt                time.Time     `json:"updated_at"`
+	Players                  []Player         `json:"players"`
+	ValidationErrors         []ValidationError `json:"validation_errors,omitempty"`
+	CanStart                 bool             `json:"can_start"`
+	CreatedAt                time.Time        `json:"created_at"`
+	UpdatedAt                time.Time        `json:"updated_at"`
 }
 
 type Player struct {

--- a/internal/gamemode/americano/service.go
+++ b/internal/gamemode/americano/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fabianthorsen/openpadel/internal/domain"
+	"github.com/fabianthorsen/openpadel/internal/pairing/americano"
 )
 
 // Store is the subset of store.Store methods used by this service.
@@ -29,8 +30,8 @@ func New(store Store) *Service {
 // Returns a non-nil error only if it has already written an HTTP error response.
 func (s *Service) Start(w http.ResponseWriter, sessionID string, sess *domain.Session, active []domain.Player, endsAt *time.Time) error {
 	rand.Shuffle(len(active), func(i, j int) { active[i], active[j] = active[j], active[i] })
-	totalRounds := TotalRounds(len(active), sess.Courts)
-	rounds := Generate(active, sess.Courts, totalRounds)
+	totalRounds := americano.TotalRounds(len(active), sess.Courts)
+	rounds := americano.GenerateRounds(active, sess.Courts, totalRounds)
 	if err := s.store.SaveRounds(sessionID, rounds); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error")
 		return err

--- a/internal/pairing/americano/scheduler.go
+++ b/internal/pairing/americano/scheduler.go
@@ -1,0 +1,263 @@
+package americano
+
+import (
+	"crypto/rand"
+	"math/big"
+	"sort"
+
+	"github.com/fabianthorsen/openpadel/internal/domain"
+)
+
+// GenerateRounds produces all rounds for an Americano session upfront.
+// Hard constraint: a player benched in round N must play in round N+1.
+// Core invariant: minimise partner and matchup repeats across the full tournament.
+func GenerateRounds(players []domain.Player, courts, totalRounds int) []domain.Round {
+	ids := make([]string, len(players))
+	for i, p := range players {
+		ids[i] = p.ID
+	}
+
+	benchSize := len(ids) - courts*4
+
+	lastBenchedRound := make(map[string]int) // 0 = never benched
+	benchTotal := make(map[string]int)
+
+	// Full history — not just the previous round.
+	partnerCount := map[[2]string]int{}
+	matchupCount := map[[4]string]int{}
+
+	rounds := make([]domain.Round, totalRounds)
+
+	for r := 0; r < totalRounds; r++ {
+		roundNum := r + 1
+
+		// Players who sat out last round must play this round.
+		mustPlay := make(map[string]bool)
+		if roundNum > 1 {
+			for _, id := range ids {
+				if lastBenchedRound[id] == roundNum-1 {
+					mustPlay[id] = true
+				}
+			}
+		}
+
+		var forced, canBench []string
+		for _, id := range ids {
+			if mustPlay[id] {
+				forced = append(forced, id)
+			} else {
+				canBench = append(canBench, id)
+			}
+		}
+
+		// From canBench, those with fewest bench turns are most "due" to sit.
+		sort.Slice(canBench, func(i, j int) bool {
+			return benchTotal[canBench[i]] < benchTotal[canBench[j]]
+		})
+
+		var bench, active []string
+		if benchSize > 0 {
+			actualBenchSize := benchSize
+			if actualBenchSize > len(canBench) {
+				actualBenchSize = len(canBench)
+			}
+			bench = canBench[:actualBenchSize]
+			active = append(forced, canBench[actualBenchSize:]...)
+		} else {
+			active = append([]string{}, ids...)
+		}
+
+		for _, id := range bench {
+			lastBenchedRound[id] = roundNum
+			benchTotal[id]++
+		}
+
+		matches := assignCourts(active, courts, partnerCount, matchupCount)
+		shuffleTeamSides(matches)
+
+		for _, m := range matches {
+			partnerCount[pairKey(m.TeamA[0], m.TeamA[1])]++
+			partnerCount[pairKey(m.TeamB[0], m.TeamB[1])]++
+			matchupCount[matchupKey(m.TeamA[0], m.TeamA[1], m.TeamB[0], m.TeamB[1])]++
+		}
+
+		benchIDs := make([]string, len(bench))
+		copy(benchIDs, bench)
+
+		rounds[r] = domain.Round{
+			ID:      shortID(),
+			Number:  roundNum,
+			Bench:   benchIDs,
+			Matches: matches,
+		}
+	}
+
+	return rounds
+}
+
+// pairKey returns a canonical (sorted) key for a partnership.
+func pairKey(a, b string) [2]string {
+	if a > b {
+		return [2]string{b, a}
+	}
+	return [2]string{a, b}
+}
+
+// matchupKey returns a canonical key for a court matchup.
+// {A+B vs C+D} == {C+D vs A+B}, so both teams are sorted.
+func matchupKey(a0, a1, b0, b1 string) [4]string {
+	pa := pairKey(a0, a1)
+	pb := pairKey(b0, b1)
+	if pa[0] > pb[0] || (pa[0] == pb[0] && pa[1] > pb[1]) {
+		pa, pb = pb, pa
+	}
+	return [4]string{pa[0], pa[1], pb[0], pb[1]}
+}
+
+// bestPartnerMatching finds the partner pairing of players that minimises total
+// partner-repeat count using backtracking with pruning. For up to 16 players the
+// search tree is small enough to be exhaustive (worst case: 10,395 nodes for 12p).
+func bestPartnerMatching(players []string, partnerCount map[[2]string]int) [][2]string {
+	n := len(players)
+	used := make([]bool, n)
+	scratch := make([][2]string, n/2)
+	best := make([][2]string, n/2)
+	bestScore := int(^uint(0) >> 1)
+
+	var bt func(pairIdx, score int)
+	bt = func(pairIdx, score int) {
+		if score >= bestScore {
+			return // prune: can't beat current best
+		}
+		if pairIdx == n/2 {
+			bestScore = score
+			copy(best, scratch)
+			return
+		}
+		// Always pair the first unused player — reduces branching factor.
+		first := -1
+		for i := range players {
+			if !used[i] {
+				first = i
+				break
+			}
+		}
+		used[first] = true
+		for second := first + 1; second < n; second++ {
+			if !used[second] {
+				used[second] = true
+				scratch[pairIdx] = [2]string{players[first], players[second]}
+				bt(pairIdx+1, score+partnerCount[pairKey(players[first], players[second])]*1000)
+				used[second] = false
+			}
+		}
+		used[first] = false
+	}
+
+	bt(0, 0)
+	return best
+}
+
+// bestCourtAssignment groups the given partner pairs into courts, minimising
+// matchup repeats. Number of groupings: for 4 pairs→3, 6 pairs→15, 8 pairs→105.
+func bestCourtAssignment(pairs [][2]string, matchupCount map[[4]string]int) []domain.Match {
+	numPairs := len(pairs)
+	courts := numPairs / 2
+	usedPair := make([]bool, numPairs)
+	scratch := make([]domain.Match, courts)
+	best := make([]domain.Match, courts)
+	bestScore := int(^uint(0) >> 1)
+
+	var bt func(courtIdx, score int)
+	bt = func(courtIdx, score int) {
+		if score >= bestScore {
+			return
+		}
+		if courtIdx == courts {
+			bestScore = score
+			copy(best, scratch)
+			return
+		}
+		// Fix the first unused pair as TeamA of this court.
+		first := -1
+		for i := range pairs {
+			if !usedPair[i] {
+				first = i
+				break
+			}
+		}
+		usedPair[first] = true
+		for second := first + 1; second < numPairs; second++ {
+			if !usedPair[second] {
+				usedPair[second] = true
+				a0, a1 := pairs[first][0], pairs[first][1]
+				b0, b1 := pairs[second][0], pairs[second][1]
+				scratch[courtIdx] = domain.Match{
+					ID:    shortID(),
+					Court: courtIdx + 1,
+					TeamA: [2]string{a0, a1},
+					TeamB: [2]string{b0, b1},
+				}
+				bt(courtIdx+1, score+matchupCount[matchupKey(a0, a1, b0, b1)]*10)
+				usedPair[second] = false
+			}
+		}
+		usedPair[first] = false
+	}
+
+	bt(0, 0)
+	return best
+}
+
+// assignCourts finds the optimal assignment of active players to courts using
+// exact backtracking search: first minimise partner repeats (primary constraint),
+// then minimise matchup repeats (secondary). Guaranteed optimal for up to 16 players.
+func assignCourts(active []string, courts int, partnerCount map[[2]string]int, matchupCount map[[4]string]int) []domain.Match {
+	pairs := bestPartnerMatching(active, partnerCount)
+	return bestCourtAssignment(pairs, matchupCount)
+}
+
+// TotalRounds returns the correct number of rounds for a fair Americano tournament.
+// For no-bench configs (players == courts*4): N-1 rounds covers all unique pairs.
+// For bench configs: smallest multiple of N/gcd(N,benchSize) that is >= N-1,
+// ensuring everyone sits out equally AND there are enough rounds to be meaningful.
+func TotalRounds(players, courts int) int {
+	benchSize := players - courts*4
+	if benchSize <= 0 {
+		return players - 1
+	}
+	cycle := players / gcd(players, benchSize) // rounds per full bench rotation
+	target := players - 1                       // minimum meaningful rounds
+	// Round up to the nearest full cycle >= target
+	n := (target + cycle - 1) / cycle
+	return n * cycle
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+// shuffleTeamSides randomly swaps Team A and Team B on each match so that the
+// "Team A" label doesn't persistently attach to any particular player across rounds.
+func shuffleTeamSides(matches []domain.Match) {
+	for i := range matches {
+		n, _ := rand.Int(rand.Reader, big.NewInt(2))
+		if n.Int64() == 1 {
+			matches[i].TeamA, matches[i].TeamB = matches[i].TeamB, matches[i].TeamA
+		}
+	}
+}
+
+const idAlphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+func shortID() string {
+	b := make([]byte, 6)
+	for i := range b {
+		idx, _ := rand.Int(rand.Reader, big.NewInt(int64(len(idAlphabet))))
+		b[i] = idAlphabet[idx.Int64()]
+	}
+	return string(b)
+}

--- a/internal/store/db/users.sql.go
+++ b/internal/store/db/users.sql.go
@@ -135,7 +135,7 @@ SELECT
         END
     ), 0) AS INTEGER) AS total_points
 FROM players p
-JOIN sessions s ON s.id = p.session_id AND s.status = 'complete' AND s.game_mode == 'americano'
+JOIN sessions s ON s.id = p.session_id AND s.status = 'done' AND s.game_mode == 'americano'
 LEFT JOIN rounds r ON r.session_id = p.session_id
 LEFT JOIN matches m ON m.round_id = r.id
     AND (m.p1 = p.id OR m.p2 = p.id OR m.p3 = p.id OR m.p4 = p.id)
@@ -189,7 +189,7 @@ SELECT
     COALESCE(s.ended_early, 0) AS ended_early
 FROM players p
 JOIN sessions s ON s.id = p.session_id
-WHERE p.user_id = ? AND p.active = 1 AND s.status = 'complete'
+WHERE p.user_id = ? AND p.active = 1 AND s.status = 'done'
 GROUP BY s.id
 ORDER BY s.created_at DESC
 `
@@ -243,7 +243,7 @@ SELECT
 FROM players p
 JOIN sessions s ON s.id = p.session_id
 LEFT JOIN players p2 ON p2.session_id = s.id AND p2.active = 1
-WHERE p.user_id = ? AND p.active = 1 AND s.status IN ('lobby', 'active')
+WHERE p.user_id = ? AND p.active = 1 AND s.status IN ('lobby', 'playing')
 GROUP BY s.id
 ORDER BY s.status DESC, COALESCE(s.scheduled_at, s.created_at) ASC
 `

--- a/internal/store/queries/users.sql
+++ b/internal/store/queries/users.sql
@@ -53,7 +53,7 @@ SELECT
         END
     ), 0) AS INTEGER) AS total_points
 FROM players p
-JOIN sessions s ON s.id = p.session_id AND s.status = 'complete' AND s.game_mode == 'americano'
+JOIN sessions s ON s.id = p.session_id AND s.status = 'done' AND s.game_mode == 'americano'
 LEFT JOIN rounds r ON r.session_id = p.session_id
 LEFT JOIN matches m ON m.round_id = r.id
     AND (m.p1 = p.id OR m.p2 = p.id OR m.p3 = p.id OR m.p4 = p.id)
@@ -81,7 +81,7 @@ SELECT
     COALESCE(s.ended_early, 0) AS ended_early
 FROM players p
 JOIN sessions s ON s.id = p.session_id
-WHERE p.user_id = ? AND p.active = 1 AND s.status = 'complete'
+WHERE p.user_id = ? AND p.active = 1 AND s.status = 'done'
 GROUP BY s.id
 ORDER BY s.created_at DESC;
 
@@ -97,7 +97,7 @@ SELECT
 FROM players p
 JOIN sessions s ON s.id = p.session_id
 LEFT JOIN players p2 ON p2.session_id = s.id AND p2.active = 1
-WHERE p.user_id = ? AND p.active = 1 AND s.status IN ('lobby', 'active')
+WHERE p.user_id = ? AND p.active = 1 AND s.status IN ('lobby', 'playing')
 GROUP BY s.id
 ORDER BY s.status DESC, COALESCE(s.scheduled_at, s.created_at) ASC;
 

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -100,7 +100,7 @@ func (s *Store) StartSession(id string, roundsTotal int, endsAt *time.Time) erro
 		endsAtStr = sql.NullString{String: endsAt.UTC().Format(time.RFC3339), Valid: true}
 	}
 	return s.queries.StartSession(context.Background(), db.StartSessionParams{
-		Status:      string(domain.StatusActive),
+		Status:      string(domain.StatusPlaying),
 		RoundsTotal: sql.NullInt64{Int64: int64(roundsTotal), Valid: true},
 		EndsAt:      endsAtStr,
 		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
@@ -116,7 +116,7 @@ func (s *Store) StartMexicanoSession(id string, endsAt *time.Time) error {
 		endsAtStr = sql.NullString{String: endsAt.UTC().Format(time.RFC3339), Valid: true}
 	}
 	return s.queries.StartMexicanoSession(context.Background(), db.StartMexicanoSessionParams{
-		Status:    string(domain.StatusActive),
+		Status:    string(domain.StatusPlaying),
 		EndsAt:    endsAtStr,
 		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
 		ID:        id,
@@ -145,7 +145,7 @@ func (s *Store) CompleteSession(id string, endedEarly bool) error {
 		endedEarlyInt = 1
 	}
 	return s.queries.CompleteSession(context.Background(), db.CompleteSessionParams{
-		Status:     string(domain.StatusComplete),
+		Status:     string(domain.StatusDone),
 		EndedEarly: endedEarlyInt,
 		UpdatedAt:  time.Now().UTC().Format(time.RFC3339),
 		ID:         id,

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -52,7 +52,7 @@ func TestCompleteSession_EndedEarly(t *testing.T) {
 		t.Fatalf("GetSession: %v", err)
 	}
 
-	if loaded.Status != domain.StatusComplete {
+	if loaded.Status != domain.StatusDone {
 		t.Errorf("expected status 'complete', got %q", loaded.Status)
 	}
 }
@@ -70,7 +70,7 @@ func TestCompleteSession_NaturalCompletion(t *testing.T) {
 		t.Fatalf("GetSession: %v", err)
 	}
 
-	if loaded.Status != domain.StatusComplete {
+	if loaded.Status != domain.StatusDone {
 		t.Errorf("expected status 'complete', got %q", loaded.Status)
 	}
 }


### PR DESCRIPTION
## Summary
- Extract Americano pairing logic into dedicated `internal/pairing/americano/scheduler.go` module
- Add structured constraint validation with `AmericanoConstraints()` and `MexicanoConstraints()` functions
- Implement server-side validation in session API handlers with structured error codes for i18n

## Implementation Details

### Issue #60 - Americano Service Refactor
- Extract `GenerateRounds()` and `TotalRounds()` into pairing scheduler module
- Update `americano/service.go` to call scheduler functions instead of internal Generate() calls
- Maintain all constraint enforcement: no consecutive bench, balanced distribution, partner/opponent variety minimization

### Issue #63 - State Validation & API Contracts
- Create `ValidationError` struct with Code and Params fields for structured error responses
- Add `ValidationErrors []ValidationError` and `CanStart bool` fields to Session struct
- Compute validation errors in `getSession()` for lobby state sessions
- Validate constraints in `startSession()` before allowing start, return 400 with structured errors if invalid
- Update all status constants from old values (active, complete) to new values (playing, done)
- Fix all test assertions to expect new status values

## Test Results
All tests passing: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)