### PR TITLE
feat: update ActiveSession for playing/done states (closes #65)

### DIFF
--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -19,7 +19,7 @@ declare global {
       tournaments: number;
     }
 
-    type SessionStatus = 'lobby' | 'active' | 'complete';
+    type SessionStatus = 'lobby' | 'playing' | 'done';
 
     interface Session {
       id: string;
@@ -97,7 +97,7 @@ declare global {
     interface UpcomingEntry {
       session_id: string;
       name: string;
-      status: 'lobby' | 'active';
+      status: 'lobby' | 'playing';
       game_mode: 'americano' | 'mexicano';
       courts: number;
       player_count: number;

--- a/web/src/lib/stores/sessionStream.test.ts
+++ b/web/src/lib/stores/sessionStream.test.ts
@@ -61,9 +61,9 @@ describe('sessionStream', () => {
     const handler = vi.fn();
     stream.onEvent('session_updated', handler);
 
-    MockEventSource.instances[0].emit('session_updated', { status: 'active' });
+    MockEventSource.instances[0].emit('session_updated', { status: 'playing' });
 
-    expect(handler).toHaveBeenCalledWith({ status: 'active' });
+    expect(handler).toHaveBeenCalledWith({ status: 'playing' });
     stream.close();
   });
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -62,7 +62,7 @@
     try {
       const token = localStorage.getItem(`admin_token_${lastId}`) ?? undefined;
       const s = await api.sessions.get(lastId, token);
-      if (s.status === 'lobby' || s.status === 'active') {
+      if (s.status === 'lobby' || s.status === 'playing') {
         rejoinSession = s;
         rejoinHref = token ? `/s/${lastId}?token=${token}` : `/s/${lastId}`;
       } else {

--- a/web/src/routes/profile/+page.svelte
+++ b/web/src/routes/profile/+page.svelte
@@ -591,13 +591,13 @@
             {:else}
               {#each upcoming as t}
                 <a href={sessionHref(t.session_id)} class="flex items-center gap-4 rounded-2xl bg-surface-raised px-4 py-3.5 transition-colors hover:bg-border">
-                  <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full {t.status === 'active' ? 'bg-emerald-500/15 text-emerald-500' : 'bg-primary-muted text-primary'}">
-                    {#if t.status === 'active'}<Radio size={18} />{:else}<CalendarDays size={18} />{/if}
+                  <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full {t.status === 'playing' ? 'bg-emerald-500/15 text-emerald-500' : 'bg-primary-muted text-primary'}">
+                    {#if t.status === 'playing'}<Radio size={18} />{:else}<CalendarDays size={18} />{/if}
                   </div>
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
                       <p class="truncate font-semibold text-sm">{t.name}</p>
-                      {#if t.status === 'active'}
+                      {#if t.status === 'playing'}
                         <span class="shrink-0 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-emerald-500">Live</span>
                       {/if}
                     </div>

--- a/web/src/routes/s/[id]/+page.svelte
+++ b/web/src/routes/s/[id]/+page.svelte
@@ -108,9 +108,9 @@
     </main>
   {:else if session.status === 'lobby'}
       <Lobby {session} {isAdmin} onRefresh={load} onStarted={load} {stream} />
-  {:else if session.status === 'active' && currentRound}
+  {:else if session.status === 'playing' && currentRound}
       <ActiveSession {session} {currentRound} {isAdmin} onRefresh={load} {stream} />
-  {:else if session.status === 'complete'}
+  {:else if session.status === 'done'}
     <Leaderboard sessionId={session.id} sessionName={session.name} complete />
   {:else}
     <main class="flex flex-1 items-center justify-center px-4">


### PR DESCRIPTION
## Summary
Update all frontend references to session status from old values (active, complete) to new values (playing, done), matching the backend state machine redesign.

## Implementation Details

### Issue #65 - Update ActiveSession for playing/done states
- Update SessionStatus type definition from `'lobby' | 'active' | 'complete'` to `'lobby' | 'playing' | 'done'`
- Update UpcomingEntry type to use `'playing'` instead of `'active'`
- Update session page (s/[id]/+page.svelte) to check for `'playing'` and `'done'` status
- Update home page (+page.svelte) to check for `'playing'` in rejoin logic
- Update profile page to display `'playing'` status for active tournaments
- Update sessionStream test to use `'playing'` test data

All frontend type definitions and status checks now align with backend state machine.

## Test Results
No new tests added (all frontend status checks are type-safe via TypeScript, which passes svelte-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)