### PR TITLE
test(#66): add integration tests for state machine & validation

### DIFF
--- a/internal/api/sessions_test.go
+++ b/internal/api/sessions_test.go
@@ -473,3 +473,52 @@ func TestInvalidTransition_CannotStartInPlaying(t *testing.T) {
 	}
 	res.Body.Close()
 }
+
+func TestPlayerJoin_CanJoinInLobby(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, _ := mustCreateSession(t, srv, "")
+
+	// Player should be able to join in lobby state
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/players", map[string]any{"name": "Alice"}, "")
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", res.StatusCode)
+	}
+	var player struct {
+		ID string `json:"id"`
+	}
+	decodeBody(t, res, &player)
+	if player.ID == "" {
+		t.Error("expected non-empty player ID")
+	}
+}
+
+func TestPlayerJoin_CannotJoinInPlaying(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, _, _ := setupStartedSession(t, srv)
+
+	// Player should NOT be able to join once session is playing
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/players", map[string]any{"name": "Eve"}, "")
+	if res.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+}
+
+func TestPlayerJoin_CannotJoinInDone(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken, _ := setupStartedSession(t, srv)
+
+	// Close the session
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/close", nil, adminToken)
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("close: expected 204, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+
+	// Player should NOT be able to join in done state
+	res2 := postReq(t, srv, "/api/sessions/"+sessID+"/players", map[string]any{"name": "Eve"}, "")
+	if res2.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", res2.StatusCode)
+	}
+	res2.Body.Close()
+}

--- a/internal/api/sessions_test.go
+++ b/internal/api/sessions_test.go
@@ -522,3 +522,66 @@ func TestPlayerJoin_CannotJoinInDone(t *testing.T) {
 	}
 	res2.Body.Close()
 }
+
+func TestSessionConfig_CourtDurationMinutes(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+
+	// Create session with custom court duration
+	duration := 60
+	res := postReq(t, srv, "/api/sessions", map[string]any{
+		"courts":                   1,
+		"points":                   24,
+		"game_mode":                "americano",
+		"court_duration_minutes":   duration,
+	}, "")
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", res.StatusCode)
+	}
+	var sess struct {
+		ID                   string `json:"id"`
+		CourtDurationMinutes *int   `json:"court_duration_minutes"`
+	}
+	decodeBody(t, res, &sess)
+
+	// Verify duration is stored and returned
+	if sess.CourtDurationMinutes == nil || *sess.CourtDurationMinutes != duration {
+		t.Errorf("expected court_duration_minutes %d, got %v", duration, sess.CourtDurationMinutes)
+	}
+
+	// Verify duration is returned on get
+	res2 := getReq(t, srv, "/api/sessions/"+sess.ID, "")
+	var sess2 struct {
+		CourtDurationMinutes *int `json:"court_duration_minutes"`
+	}
+	decodeBody(t, res2, &sess2)
+	if sess2.CourtDurationMinutes == nil || *sess2.CourtDurationMinutes != duration {
+		t.Errorf("expected court_duration_minutes %d, got %v", duration, sess2.CourtDurationMinutes)
+	}
+}
+
+func TestSessionConfig_InvalidCourtDuration(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+
+	testCases := []struct {
+		name     string
+		duration int
+	}{
+		{"too_small", 10},
+		{"too_large", 400},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := postReq(t, srv, "/api/sessions", map[string]any{
+				"courts":                   1,
+				"points":                   24,
+				"game_mode":                "americano",
+				"court_duration_minutes":   tc.duration,
+			}, "")
+			if res.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", res.StatusCode)
+			}
+			res.Body.Close()
+		})
+	}
+}

--- a/internal/api/sessions_test.go
+++ b/internal/api/sessions_test.go
@@ -217,3 +217,259 @@ func TestCancelSession_RequiresAdmin(t *testing.T) {
 	}
 	res.Body.Close()
 }
+
+// Integration tests for state machine & validation (Issue #66)
+
+func TestStateFlow_LobbyToPlayingToDone(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken, _ := setupStartedSession(t, srv)
+
+	// Verify session is in playing state
+	res := getReq(t, srv, "/api/sessions/"+sessID, adminToken)
+	var sess struct {
+		Status string `json:"status"`
+	}
+	decodeBody(t, res, &sess)
+	if sess.Status != "playing" {
+		t.Fatalf("expected status 'playing', got %q", sess.Status)
+	}
+
+	// Close the session (manual end)
+	res2 := postReq(t, srv, "/api/sessions/"+sessID+"/close", nil, adminToken)
+	if res2.StatusCode != http.StatusNoContent {
+		t.Fatalf("close: expected 204, got %d", res2.StatusCode)
+	}
+	res2.Body.Close()
+
+	// Verify session is now in done state
+	res3 := getReq(t, srv, "/api/sessions/"+sessID, adminToken)
+	decodeBody(t, res3, &sess)
+	if sess.Status != "done" {
+		t.Fatalf("expected status 'done' after close, got %q", sess.Status)
+	}
+}
+
+func TestStateFlow_DeleteInLobby(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSession(t, srv, "")
+
+	// Join some players
+	mustJoinSession(t, srv, sessID, "Alice", adminToken)
+	mustJoinSession(t, srv, sessID, "Bob", "")
+
+	// Delete the session in lobby state
+	res := deleteReq(t, srv, "/api/sessions/"+sessID, adminToken)
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+
+	// Verify session no longer exists
+	res2 := getReq(t, srv, "/api/sessions/"+sessID, "")
+	if res2.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 after delete, got %d", res2.StatusCode)
+	}
+	res2.Body.Close()
+}
+
+func TestAmericanoConstraints_StartSucceeds_1Court4Players(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSessionWithParams(t, srv, "", 1, 24, "americano")
+
+	// Join 4 players for 1 court (minimum for Americano)
+	mustJoinSession(t, srv, sessID, "Alice", adminToken)
+	mustJoinSession(t, srv, sessID, "Bob", "")
+	mustJoinSession(t, srv, sessID, "Charlie", "")
+	mustJoinSession(t, srv, sessID, "Diana", "")
+
+	// Should succeed
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+
+	// Verify status changed to playing
+	res2 := getReq(t, srv, "/api/sessions/"+sessID, adminToken)
+	var sess struct {
+		Status string `json:"status"`
+	}
+	decodeBody(t, res2, &sess)
+	if sess.Status != "playing" {
+		t.Fatalf("expected 'playing', got %q", sess.Status)
+	}
+}
+
+func TestAmericanoConstraints_StartFails_1Court3Players(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSessionWithParams(t, srv, "", 1, 24, "americano")
+
+	// Join only 3 players for 1 court (below minimum)
+	mustJoinSession(t, srv, sessID, "Alice", adminToken)
+	mustJoinSession(t, srv, sessID, "Bob", "")
+	mustJoinSession(t, srv, sessID, "Charlie", "")
+
+	// Should fail with 400
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+}
+
+func TestAmericanoConstraints_StartSucceeds_2Courts8Players(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSessionWithParams(t, srv, "", 2, 24, "americano")
+
+	// Join 8 players for 2 courts
+	for i, name := range []string{"Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace", "Henry"} {
+		token := ""
+		if i == 0 {
+			token = adminToken
+		}
+		mustJoinSession(t, srv, sessID, name, token)
+	}
+
+	// Should succeed
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+
+	// Verify status changed to playing
+	res2 := getReq(t, srv, "/api/sessions/"+sessID, adminToken)
+	var sess struct {
+		Status string `json:"status"`
+	}
+	decodeBody(t, res2, &sess)
+	if sess.Status != "playing" {
+		t.Fatalf("expected 'playing', got %q", sess.Status)
+	}
+}
+
+func TestMexicanoConstraints_StartSucceeds_2Courts8Players(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSessionWithParams(t, srv, "", 2, 24, "mexicano")
+
+	// Join exactly 8 players for 2 courts in Mexicano
+	for i, name := range []string{"Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace", "Henry"} {
+		token := ""
+		if i == 0 {
+			token = adminToken
+		}
+		mustJoinSession(t, srv, sessID, name, token)
+	}
+
+	// Should succeed
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+
+	// Verify status changed to playing
+	res2 := getReq(t, srv, "/api/sessions/"+sessID, adminToken)
+	var sess struct {
+		Status string `json:"status"`
+	}
+	decodeBody(t, res2, &sess)
+	if sess.Status != "playing" {
+		t.Fatalf("expected 'playing', got %q", sess.Status)
+	}
+}
+
+func TestMexicanoConstraints_StartFails_2Courts7Players(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSessionWithParams(t, srv, "", 2, 24, "mexicano")
+
+	// Join 7 players (below required 8)
+	for i, name := range []string{"Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace"} {
+		token := ""
+		if i == 0 {
+			token = adminToken
+		}
+		mustJoinSession(t, srv, sessID, name, token)
+	}
+
+	// Should fail with 400
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+}
+
+func TestMexicanoConstraints_StartFails_2Courts9Players(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSessionWithParams(t, srv, "", 2, 24, "mexicano")
+
+	// Join 9 players (above maximum 8)
+	for i, name := range []string{"Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace", "Henry", "Ivy"} {
+		token := ""
+		if i == 0 {
+			token = adminToken
+		}
+		mustJoinSession(t, srv, sessID, name, token)
+	}
+
+	// Should fail with 400
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+}
+
+func TestInvalidTransition_CanCloseInLobby(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken := mustCreateSession(t, srv, "")
+
+	// Verify can close in lobby state
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/close", nil, adminToken)
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+
+	// Verify status is done
+	res2 := getReq(t, srv, "/api/sessions/"+sessID, adminToken)
+	var sess struct {
+		Status string `json:"status"`
+	}
+	decodeBody(t, res2, &sess)
+	if sess.Status != "done" {
+		t.Fatalf("expected 'done', got %q", sess.Status)
+	}
+}
+
+func TestInvalidTransition_CannotCloseInDone(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken, _ := setupStartedSession(t, srv)
+
+	// Close the session
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/close", nil, adminToken)
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("close: expected 204, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+
+	// Try to close again - should fail with 409 (conflict)
+	res2 := postReq(t, srv, "/api/sessions/"+sessID+"/close", nil, adminToken)
+	if res2.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", res2.StatusCode)
+	}
+	res2.Body.Close()
+}
+
+func TestInvalidTransition_CannotStartInPlaying(t *testing.T) {
+	srv, _ := newAPITestServer(t)
+	sessID, adminToken, _ := setupStartedSession(t, srv)
+
+	// Try to start again - should fail with 409 (conflict)
+	res := postReq(t, srv, "/api/sessions/"+sessID+"/start", nil, adminToken)
+	if res.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", res.StatusCode)
+	}
+	res.Body.Close()
+}

--- a/internal/api/testhelpers_test.go
+++ b/internal/api/testhelpers_test.go
@@ -119,13 +119,19 @@ func mustRegister(t *testing.T, srv *httptest.Server, emailAddr, name, password 
 // mustCreateSession creates an americano session and returns its ID and admin token.
 func mustCreateSession(t *testing.T, srv *httptest.Server, token string) (id, adminToken string) {
 	t.Helper()
+	return mustCreateSessionWithParams(t, srv, token, 1, 24, "americano")
+}
+
+// mustCreateSessionWithParams creates a session with custom parameters and returns its ID and admin token.
+func mustCreateSessionWithParams(t *testing.T, srv *httptest.Server, token string, courts, points int, gameMode string) (id, adminToken string) {
+	t.Helper()
 	res := postReq(t, srv, "/api/sessions", map[string]any{
-		"courts":    1,
-		"points":    24,
-		"game_mode": "americano",
+		"courts":    courts,
+		"points":    points,
+		"game_mode": gameMode,
 	}, token)
 	if res.StatusCode != http.StatusCreated {
-		t.Fatalf("createSession: expected 201, got %d", res.StatusCode)
+		t.Fatalf("createSession: expected 201, got %d, response: %v", res.StatusCode, res.Body)
 	}
 	var body struct {
 		ID         string `json:"id"`


### PR DESCRIPTION
Closes #66

## Summary

Add comprehensive integration tests verifying the 3-state session machine (lobby → playing → done) and constraint validation for both Americano and Mexicano game modes.

### State Flow & Transitions
- State flow transitions with manual early close (lobby → playing → done)
- Session deletion in lobby
- Invalid state transitions (cannot close/start already-ended sessions)

### Game Mode Constraints
- Americano: 1 court requires 4+ players, 2 courts require 8+ players
- Mexicano: 2 courts requires exactly 8 players (fails with 7 or 9)

### Player Join Restrictions
- Players can only join in lobby state
- Cannot join once session is playing (409 conflict)
- Cannot join once session is done (409 conflict)

### Session Configuration
- Can create session with custom court_duration_minutes (15-300)
- Configuration is persisted and returned in responses
- Invalid configurations are rejected (400)

All tests verify proper HTTP status codes and session state changes.

## Test Plan

- [x] State flow: lobby → playing → done with manual close
- [x] Deletion in lobby state
- [x] Americano 1 court with 4 players succeeds
- [x] Americano 1 court with 3 players fails (400)
- [x] Americano 2 courts with 8 players succeeds
- [x] Mexicano 2 courts with 8 players succeeds
- [x] Mexicano 2 courts with 7 players fails (400)
- [x] Mexicano 2 courts with 9 players fails (400)
- [x] Cannot close session in done state (409 conflict)
- [x] Cannot start session in playing state (409 conflict)
- [x] Players can join in lobby state
- [x] Players cannot join in playing state (409)
- [x] Players cannot join in done state (409)
- [x] Session can be created with court_duration_minutes
- [x] Configuration is returned in session response
- [x] Invalid court duration rejected (400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)