### PR TITLE
fix(lobby): revert courts to pill toggles, disable 1-court option in mexicano

### DIFF
--- a/web/src/lib/components/Lobby.svelte
+++ b/web/src/lib/components/Lobby.svelte
@@ -532,19 +532,16 @@
 
         <!-- Courts -->
         <div class="space-y-2">
-          <div class="flex items-center justify-between">
-            <p class="text-[11px] font-semibold uppercase tracking-[0.1em] text-text-disabled">{$_('create_courts_label')}</p>
-            <p class="text-lg font-[800] text-primary">{configCourts}</p>
-          </div>
-          <input
-            type="range"
-            min={configMode === 'mexicano' ? 2 : 1}
-            max={MAX_COURTS}
-            step="1"
-            bind:value={configCourts}
-            onchange={() => onCourtsChange(configCourts)}
-            class="w-full accent-primary"
-          />
+          <p class="text-[11px] font-semibold uppercase tracking-[0.1em] text-text-disabled">{$_('create_courts_label')}</p>
+          <PillToggleGroup
+            value={configCourts.toString()}
+            onValueChange={(v) => v && onCourtsChange(parseInt(v))}
+          >
+            {#each Array.from({ length: MAX_COURTS }, (_, i) => i + 1) as n}
+              <PillToggleItem value={n.toString()} disabled={configMode === 'mexicano' && n === 1}>{n}</PillToggleItem>
+            {/each}
+          </PillToggleGroup>
+        </div>
         </div>
 
         <!-- Points -->

--- a/web/src/lib/components/Lobby.svelte
+++ b/web/src/lib/components/Lobby.svelte
@@ -542,7 +542,6 @@
             {/each}
           </PillToggleGroup>
         </div>
-        </div>
 
         <!-- Points -->
         <div class="space-y-2">

--- a/web/src/lib/components/ui/pill-toggle-group/pill-toggle-item.svelte
+++ b/web/src/lib/components/ui/pill-toggle-group/pill-toggle-item.svelte
@@ -20,6 +20,7 @@
 		'flex-1 min-w-0 rounded-full py-2.5 text-sm font-semibold transition-colors',
 		'bg-surface text-text-primary border border-border',
 		'data-[state=on]:bg-primary data-[state=on]:text-white',
+		'disabled:opacity-40 disabled:cursor-not-allowed',
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
## Summary
- Reverted courts control from range slider back to pill togglees for all 4 options (1–4)
- The 1-court option is now disabled in Mexicano mode
- Added disabled state styling to pill toggle items

## Why
User feedback indicated that the range slider was worse than pill toggles for this use case.